### PR TITLE
quickstart: add hint mentioning UEFI

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -43,6 +43,7 @@ The Elemental Stack consists of some packages on top of SLE Micro for Rancher
  - A machine (bare metal or virtualized) with TPM 2.0
      - Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](https://rancher.github.io/elemental/tpm/#add-tpm-module-to-virtual-machine)
      - Hint 2: You can enable TPM emulation on bare metal machines missing the TPM 2.0 module [example here](https://rancher.github.io/elemental/tpm/#add-tpm-emulation-to-bare-metal-machine)
+     - Hint 3: Make sure you're using UEFI (not BIOS), or the ISO won't boot
  - Helm Package Manager (https://helm.sh/)
  - Docker (for iso manipulation)
 


### PR DESCRIPTION
Seen when testing under libvirt.  If the VM is configured with BIOS firmware, CD boot from ISO will fail with "Boot failed: Could not read from CDROM (code 0009)".  Switching to UEFI fixes this.

Signed-off-by: Tim Serong <tserong@suse.com>