### PR TITLE
Added redirects and customized 404 page

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,6 +26,91 @@ const config = {
     locales: ['en'],
   },
 
+  plugins: [
+    ["@docusaurus/plugin-client-redirects",
+      {
+        redirects: [
+          // /docs/oldDoc -> /docs/newDoc
+          {
+            to: '/installation',
+            from: '/elemental/installation',
+          },
+          {
+            to: '/',
+            from: '/elemental',
+          },
+          {
+            to: '/architecture',
+            from: '/elemental/architecture',
+          },
+          {
+            to: '/backup',
+            from: '/elemental/backup',
+          },
+          {
+            to: '/cloud-config-reference',
+            from: '/elemental/cloud-config-reference',
+          },
+          {
+            to: '/cluster-reference',
+            from: '/elemental/cluster-reference',
+          },
+          {
+            to: '/customizing',
+            from: '/elemental/customizing',
+          },
+          {
+            to: '/elemental-plans',
+            from: '/elemental/elemental-plans',
+          },
+          {
+            to: '/elementaloperatorchart-reference',
+            from: '/elemental/elementaloperatorchart-reference',
+          },
+          {
+            to: '/inventory-management',
+            from: '/elemental/inventory-management',
+          },
+          {
+            to: '/kubernetesversions',
+            from: '/elemental/kubernetesversions',
+          },
+          {
+            to: '/machineinventoryselectortemplate-reference',
+            from: '/elemental/machineinventoryselectortemplate-reference',
+          },
+          {
+            to: '/machineregistration-reference',
+            from: '/elemental/machineregistration-reference',
+          },
+          {
+            to: '/quickstart',
+            from: '/elemental/quickstart',
+          },
+          {
+            to: '/restore',
+            from: '/elemental/restore',
+          },
+          {
+            to: '/smbios',
+            from: '/elemental/smbios',
+          },
+          {
+            to: '/tpm',
+            from: '/elemental/tpm',
+          },
+          {
+            to: '/troubleshooting-restore',
+            from: '/elemental/troubleshooting-restore',
+          },
+          {
+            to: '/upgrade',
+            from: '/elemental/upgrade',
+          },
+        ],
+      },
+    ],
+  ],
   presets: [
     [
       'classic',

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.2.0",
+    "@docusaurus/plugin-client-redirects": "^2.2.0",
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",

--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import Translate, {translate} from '@docusaurus/Translate';
+import {PageMetadata} from '@docusaurus/theme-common';
+import Layout from '@theme/Layout';
+function refreshPage() {
+  window.location.reload(false);
+}
+export default function NotFound() {
+  return (
+    <>
+      <PageMetadata
+        title={translate({
+          id: 'theme.NotFound.title',
+          message: 'Page Not Found',
+        })}
+      />
+      <Layout>
+        <main className="container margin-vert--xl">
+          <div className="row">
+            <div className="col col--6 col--offset-3">
+              <h1 className="hero__title">
+                <Translate
+                  id="theme.NotFound.title"
+                  description="The title of the 404 page">
+                  Page Not Found
+                </Translate>
+              </h1>
+              <p>
+                <Translate
+                  id="theme.NotFound.p1"
+                  description="The first paragraph of the 404 page">
+                  We could not find what you were looking for.
+                </Translate>
+              </p>
+              <p>
+                <button onClick={refreshPage}>Click here</button> to refresh the page.
+                If the page moved to a new location, you'll be automatically redirected.
+              </p>
+              <p>
+                <Translate
+                  id="theme.NotFound.p2"
+                  description="The 2nd paragraph of the 404 page">
+                  Please contact the owner of the site that linked you to the
+                  original URL and let them know their link is broken.
+                </Translate>
+              </p>
+            </div>
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,6 +1327,21 @@
     react-helmet-async "*"
     react-loadable "npm:@docusaurus/react-loadable@5.5.2"
 
+"@docusaurus/plugin-client-redirects@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-2.2.0.tgz#f6228e5b2852520e22e0f4b89f870431aa975a90"
+  integrity sha512-psBoWi+cbc2I+VPkKJlcZ12tRN3xiv22tnZfNKyMo18iSY8gr4B6Q0G2KZXGPgNGJ/6gq7ATfgDK6p9h9XRxMQ==
+  dependencies:
+    "@docusaurus/core" "2.2.0"
+    "@docusaurus/logger" "2.2.0"
+    "@docusaurus/utils" "2.2.0"
+    "@docusaurus/utils-common" "2.2.0"
+    "@docusaurus/utils-validation" "2.2.0"
+    eta "^1.12.3"
+    fs-extra "^10.1.0"
+    lodash "^4.17.21"
+    tslib "^2.4.0"
+
 "@docusaurus/plugin-content-blog@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz#dc55982e76771f4e678ac10e26d10e1da2011dc1"


### PR DESCRIPTION
Due to the new URL, the Algolia search is not working. The URLs provided in the search results have the wrong "path" to the docs.

A case has been opened with Algolia and until it's fixed, as a workaround here the temporary setup:

- Added the `redirect` plugin to Docusaurus
- Added all the pages redirects in the `docusaurus.config.js`
- Modified the "page not found" (404) error message to display a button to refresh the page.

The 404 error message change is needed, as when a user clicks on a search result, Docusaurus doesn't trigger the redirect. Instead, the URL needs to be "retriggered" (page refresh) for the redirect to work.

Once the search results are updated with the new crawler configuration done by Algolia, this workaround will be retracted.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>