### PR TITLE
Add docusaurus plugin to load remote examples

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,7 +26,7 @@ const config = {
     locales: ['en'],
   },
 
-    presets: [
+  presets: [
     [
       'classic',
       /** @type {import('@docusaurus/preset-classic').Options} */
@@ -144,6 +144,17 @@ const config = {
         additionalLanguages: ['docker'],
       },
     }),
+  plugins: [
+    [
+      "docusaurus-plugin-remote-content",
+      {
+        name: "examples",
+        sourceBaseUrl: "https://raw.githubusercontent.com/rancher/elemental/main/examples/quickstart/",
+        outDir: "examples/quickstart",
+        documents: ["registration.yaml", "selector.yaml", "registration-tpm.yaml", "cluster.yaml"],
+      },
+    ],
+  ],
 };
 
 module.exports = config;

--- a/examples/quickstart/registration-tpm.yaml
+++ b/examples/quickstart/registration-tpm.yaml
@@ -16,3 +16,6 @@ spec:
         debug: true
       registration:
         emulate-tpm: true
+  machineName: my-machine
+  machineInventoryLabels:
+    location: "europe"

--- a/examples/quickstart/registration.yaml
+++ b/examples/quickstart/registration.yaml
@@ -14,7 +14,9 @@ spec:
         reboot: true
         device: /dev/sda
         debug: true
+  machineName: my-machine
   machineInventoryLabels:
+    location: "europe"
     manufacturer: "${System Information/Manufacturer}"
     productName: "${System Information/Product Name}"
     serialNumber: "${System Information/Serial Number}"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@docusaurus/preset-classic": "2.2.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
+    "docusaurus-plugin-remote-content": "^3.1.0",
     "prism-react-renderer": "^1.3.5",
     "raw-loader": "^4.0.2",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2517,6 +2517,13 @@ axios@^0.25.0:
   dependencies:
     follow-redirects "^1.14.7"
 
+axios@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 babel-loader@^8.2.5:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.3.0.tgz#124936e841ba4fe8176786d6ff28add1f134d6a8"
@@ -3418,6 +3425,16 @@ dns-packet@^5.2.2:
   dependencies:
     "@leichtgewicht/ip-codec" "^2.0.1"
 
+docusaurus-plugin-remote-content@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-remote-content/-/docusaurus-plugin-remote-content-3.1.0.tgz#d9349da5e098ba65050c5e00ef2425f3edb5e837"
+  integrity sha512-859WYmC75l9hRYa1f/2FNF+FLcKbkHCM/0dehN1Wl1fIuoFzEPf3tcWs4jcEobRHYnoMjyupqAhmu0q5j3JoIg==
+  dependencies:
+    axios "^0.26.1"
+    picocolors "^1.0.0"
+    pretty-ms "^7.0.1"
+    rimraf "^3.0.2"
+
 dom-converter@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/dom-converter/-/dom-converter-0.2.0.tgz#6721a9daee2e293682955b6afe416771627bb768"
@@ -3881,7 +3898,7 @@ flux@^4.0.1:
     fbemitter "^3.0.0"
     fbjs "^3.0.1"
 
-follow-redirects@^1.0.0, follow-redirects@^1.14.7:
+follow-redirects@^1.0.0, follow-redirects@^1.14.7, follow-redirects@^1.14.8:
   version "1.15.2"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
   integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
@@ -5395,6 +5412,11 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse-ms@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/parse-ms/-/parse-ms-2.1.0.tgz#348565a753d4391fa524029956b172cb7753097d"
+  integrity sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==
+
 parse-numeric-range@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/parse-numeric-range/-/parse-numeric-range-1.3.0.tgz#7c63b61190d61e4d53a1197f0c83c47bb670ffa3"
@@ -5811,6 +5833,13 @@ pretty-error@^4.0.0:
   dependencies:
     lodash "^4.17.20"
     renderkid "^3.0.0"
+
+pretty-ms@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/pretty-ms/-/pretty-ms-7.0.1.tgz#7d903eaab281f7d8e03c66f867e239dc32fb73e8"
+  integrity sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==
+  dependencies:
+    parse-ms "^2.1.0"
 
 pretty-time@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
**Issue**

The content of the examples did not match with the content linked (label missing)

**Solution**
Always load the latest remote examples and build with those.