### PR TITLE
Examples are in elemental-docs now

### DIFF
--- a/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/examples/upgrade/managed-os-version-channel-json.yaml
@@ -5,6 +5,6 @@ metadata:
   namespace: fleet-default
 spec:
   options:
-    URI: "https://raw.githubusercontent.com/rancher/elemental/main/examples/upgrade/versions.json"
+    URI: "https://raw.githubusercontent.com/rancher/elemental-docs/main/examples/upgrade/versions.json"
     Timeout: "1m"
   type: json


### PR DESCRIPTION
See also #27 

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>