### PR TITLE
Improve custom intallation docs and add a new example

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -100,8 +100,9 @@ According to that, the example above is expected to include the `/oem/custom_con
 * `after-install`: executed just after the after-install-chroot hook. It is not chrooted.
 * `post-install`: executed as the very last step before ending the installation, partitions are still mounted, the loop devices for the image is not.
 
-Hooks are provided as cloud-init stages. Equivalent hooks exist for `reset` and `upgrade` procedures. In fact, hooks are regular cloud-init stages,
-the difference though, is that elemental client only parses them during `install`, `upgrade` or `reset` actions, rather than boot time.
+Hooks are provided as `cloud-init` stages. Equivalent hooks exist for `reset` and `upgrade` procedures. 
+
+In fact, hooks are regular `cloud-init` stages with the only difference that Elemental client parses them during `install`, `upgrade` or `reset` actions, rather than boot time.
 
 Hooks are evaluated during `install`,`reset` and `upgrade` action from `/oem`, `/system/oem` and `/usr/local/cloud-config`, however
 additional paths can be provided with the `cloud-init-paths` flag in [Elemental client configuration](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/).

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -174,9 +174,9 @@ are created, formatted and mounted at boot time via an extended `fstab` file.
 
 For this example, the following files are required:
 
-* additional clout-init files to include within the installed system
-* additional installation hooks to prepare the LVM volumes at install time
-* additional Elemental client configuration file to point hooks file location
+* additional `clout-init` files included in the installed system
+* additional installation hooks to prepare the LVM volumes during the installation
+* additional Elemental client configuration file containing the hooks file location
 
 Lets create an `overlay` directory to create the directory tree that needs to be
 added into the ISO root. In that case the `overlay` directory could contain:

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -257,9 +257,9 @@ At this stage, the `/etc/fstab` file already exists and can be adapted before
 switching root. Once running in the final root tree, SystemD will handle the rest of the initialization and apply it.
 :::
 
-This cloud-init file should be included into the `/oem` folder on the installed
-system. `/oem` is mount point for the OEM partition. In order include extra files
-there they should be listed as `config-urls` within the Registration CRD at the
+This cloud-init file should be included into the `/oem` directory on the installed
+system. `/oem` is a mount point for the OEM partition. In order to include extra files,
+they should be listed as `config-urls` within the Registration CRD at the
 management cluster.
 
 ### Repacking the ISO image with extra files

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -42,7 +42,7 @@ To apply this pattern, the ISO needs to include:
 #### Custom Elemental client configuration file
 
 [Elemental client](https://github.com/rancher/elemental-cli) `install`, `upgrade` and `reset` commands can be configured with a
-custom [configuration file](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/).
+custom [configuration file](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/) located in the `/elemental` directory.
 
 In order to set a custom configuration file the installation ISO must include it.
 By default, the `elemental-register` command will attempt to load the Elemental client

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -191,7 +191,7 @@ overlay/
     config.yaml
 ```
 
-The Elemental client config file in `overlay/elemental` could be as:
+The Elemental client config file in `overlay/elemental` with the installation hooks path:
 
 ```yaml showLineNumbers
 cloud-init-paths:

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -165,10 +165,12 @@ Note the installation hooks only cover installation procedures, for upgrades equ
 This example is covering the setup of an host with multiple disks and some of them used
 as part of an LVM setup.
 
-In this particular case we will assume a host includes three disks (`/dev/sda`, `/dev/sdb`
-and `/dev/sdc`), where the first one is used for a regular Elemental Teal installation
-and the other remaining two are used as part of LVM group where abitrary logical volumes
-are created, formatted and mounted at boot time via an extended fstab file.
+As an example, we have an host with three disks (`/dev/sda`, `/dev/sdb`
+and `/dev/sdc`). 
+
+The first disk is used for a regular Elemental Teal installation
+and the other remaining two are used as part of a LVM group where arbitrary logical volumes
+are created, formatted and mounted at boot time via an extended `fstab` file.
 
 For that use case the following files are required:
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -251,10 +251,11 @@ stages:
         echo "LABEL=eVol2 /usr/local/eVol2  xfs defaults  0 0" >> /etc/fstab
 ```
 
-Note the `initramfs` stage is the last stage inside the initfamfs right before
-switching root to the actual root tree, in runs chrooted to the final root. At this
-stage `/etc/fstab` already exists and it is a good place to adapt it, as after
-switching root systemd will handle the rest of the initalizaton and process apply it.
+:::note
+The `initramfs` stage is the last stage before switching to the actual root tree.
+At this stage, the `/etc/fstab` file already exists and can be adapted before
+switching root. Once running in the final root tree, SystemD will handle the rest of the initialization and apply it.
+:::
 
 This cloud-init file should be included into the `/oem` folder on the installed
 system. `/oem` is mount point for the OEM partition. In order include extra files

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -172,7 +172,7 @@ The first disk is used for a regular Elemental Teal installation
 and the other remaining two are used as part of a LVM group where arbitrary logical volumes
 are created, formatted and mounted at boot time via an extended `fstab` file.
 
-For that use case the following files are required:
+For this example, the following files are required:
 
 * additional clout-init files to include within the installed system
 * additional installation hooks to prepare the LVM volumes at install time

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -229,10 +229,10 @@ stages:
         mkfs.xfs -L eVol2 /dev/elementalLVM/elementalVol2
 ```
 
-It essentially creates and formats the LVM devices as desired. This is a good
-example of an installation hook, as this setup is only needed once at installation
-time. Doing such a thing on first boot is also a possibility, but it would definitely
-require a more sophisticated logic to ensure its only applied once at first boot.
+The LVM devices are created and formatted as desired. This is a good
+example of an installation hook, as this setup is only needed once, at installation
+time. As an alternative, the same action could be done on first boot, however it would
+require a more sophisticated logic to ensure it's only applied once at first boot.
 
 Finally, the boot time cloud-init files have only to take care of setting the mount
 points and actually mounting at boot. In Elemental OS fstab is ephemeral, so there is

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -267,7 +267,7 @@ management cluster.
 
 ### Repacking the ISO image with extra files
 
-¨Assuming an `overlay` folder was created in the current directory containing all
+Assuming an `overlay` folder was created in the current directory containing all
 additional files to be appended, the following `xorriso` command adds the extra files:
 
 ```bash showLineNumbers

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -234,10 +234,10 @@ example of an installation hook, as this setup is only needed once, at installat
 time. As an alternative, the same action could be done on first boot, however it would
 require a more sophisticated logic to ensure it's only applied once at first boot.
 
-Finally, the boot time cloud-init files have only to take care of setting the mount
-points and actually mounting at boot. In Elemental OS fstab is ephemeral, so there is
-no fstab set during the installation, it is dynamically created at boot time. So that
-it can't be set within an installation hook and a boot time cloud-init file is used.
+Finally, the boot time `cloud-init` files contain the mount points settings and trigger the
+action of mounting those mountpoints. The Elemental OS `fstab` file is ephemeral and it's 
+dynamically created at boot time. That's why it doesn't exist during the installation and
+can't be used in an installation hook.
 
 The `overlay/oem/lvm_volumes_hook.yaml` could something as simple as:
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -178,7 +178,7 @@ For this example, the following files are required:
 * additional installation hooks to prepare the LVM volumes during the installation
 * additional Elemental client configuration file containing the hooks file location
 
-Lets create an `overlay` directory to create the directory tree that needs to be
+Let's create an `overlay` directory to create the directory tree that needs to be
 added into the ISO root. In that case the `overlay` directory could contain:
 
 ```yaml showLineNumbers

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -118,7 +118,7 @@ For that use case the following files are required:
 * additional hooks file to copy binaries into the persistent storage and to install them
 * additional Elemental client configuration file to point hooks file location
 
-Lets create an `overlay` directory to create the directory tree that needs to be
+Let's create an `overlay` directory to create the directory tree that needs to be
 added into the ISO root. In that case the `overlay` directory could contain:
 
 ```yaml showLineNumbers

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -68,8 +68,7 @@ the `config-urls` field is used for this exact purpose. See [MachineRegistration
 cloud-init file. The local path is evaluated during
 the installation, hence it must exists within the installation media, commonly an ISO image.
 
-Since in Elemental Teal live systems the ISO root is mounted at `/run/initramfs/live`,
-the local paths for `config-url` in MachineRegistrations are likely to point there.
+By default, Elemental Teal live systems mount the ISO root at `/run/initramfs/live` and this should be the path set for `config-url` in `MachineRegistrations`:
 See the example below:
 
 ```yaml showLineNumbers

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -47,7 +47,7 @@ custom [configuration file](https://rancher.github.io/elemental-toolkit/docs/cus
 
 In order to set a custom configuration file the installation ISO must include it.
 By default, the `elemental-register` command will attempt to load the Elemental client
-configuration within the `elemental` folder in side the ISO root. That is ISOs including
+configuration within the `elemental` folder inside the ISO root. That is ISOs including
 `/elemental/config.yaml` file and/or multiple yaml files inside the `/elemental.conf.d` folder.
 
 A simple example to set hooks location could be:

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -31,8 +31,7 @@ A common pattern is to combine the three ways described above. This pattern will
 To apply this pattern, the ISO needs to include:
 
 1. A [configuration file](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/)
-   for the elemental client, at least to point installation hooks location. Commonly this is done by adding
-   a `/elemental/config.yaml` file into the ISO root.
+   for the elemental client, describing at least the installation hooks location. This file is usually added to the ISO with path and name `/elemental/config.yaml`.
 
 2. The additional cloud-init files to be included into the installed system. They
    allow to perform custom operations at boot time.

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -26,9 +26,9 @@ Elemental Teal installation can be customized in three different non-exclusive w
 some custom Elemental client configuration file, second, by including additional cloud-init files to execute at
 boot time, and finally, by including installation hooks.
 
-A common pattern is a combination of all three, this way custom steps can be added during the installation
-and additional cloud-init files can be added to the installed system so they are evaluated at boot time.
-For that to happen the ISO needs to include:
+A common pattern is to combine the three ways described above. This pattern will allow you to add custom steps during the installation and add `cloud-init` files to be evaluated at boot time.
+
+To apply this pattern, the ISO needs to include:
 
 1. A [configuration file](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/)
    for the elemental client, at least to point installation hooks location. Commonly this is done by adding

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -64,7 +64,7 @@ In order to include additional cloud-init files during the installation they nee
 to be added to the installation data into the MachineRegistration resource. More specific
 the `config-urls` field is used for this exact purpose. See [MachineRegistration reference](/machineregistration-reference) page.
 
-`config-urls` is a list of string literals where each item is an http url pointing to a
+`config-urls` is a list of string literals where each item is an HTTP URL or a local path pointing to a
 cloud-init file or a local path of a cloud init file. Note the local path is evaluated during
 the installation, hence the local path must exist within the installation media, commonly an ISO image.
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -208,12 +208,12 @@ name: "Create LVM logic volumes over some physical disks"
 stages:
   post-install:
     - name: "Create physical volume, volume group and logical volumes"
-      if: '[ -e "/dev/vdb" ] && [ -e "/dev/vdc" ]'
+      if: '[ -e "/dev/sdb" ] && [ -e "/dev/sdc" ]'
       commands:
       - | 
         # Create the physical volume, volume group and logical volumes
-        pvcreate /dev/vdb /dev/vdc
-        vgcreate elementalLVM /dev/vdb /dev/vdc
+        pvcreate /dev/sdb /dev/sdc
+        vgcreate elementalLVM /dev/sdb /dev/sdc
         lvcreate -L 8G -n elementalVol1 elementalLVM
         lvcreate -l 100%FREE -n elementalVol2 elementalLVM
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -199,7 +199,7 @@ cloud-init-paths:
 ```
 
 
-The installation hook `overlay/hooks/lvm_volumes_hook.yaml` could be as:
+The installation hook `overlay/hooks/lvm_volumes_hook.yaml`:
 
 ```yaml showLineNumbers
 name: "Create LVM logic volumes over some physical disks"

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -44,10 +44,8 @@ To apply this pattern, the ISO needs to include:
 [Elemental client](https://github.com/rancher/elemental-cli) `install`, `upgrade` and `reset` commands can be configured with a
 custom [configuration file](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/) located in the `/elemental` directory.
 
-In order to set a custom configuration file the installation ISO must include it.
-By default, the `elemental-register` command will attempt to load the Elemental client
-configuration within the `elemental` folder inside the ISO root. That is ISOs including
-`/elemental/config.yaml` file and/or multiple yaml files inside the `/elemental.conf.d` folder.
+The `elemental-register` command will also load the Elemental client configuration file
+located in the `/elemental` directory and/or multiple yaml files inside the `/elemental.conf.d` folder.
 
 A simple example to set hooks location could be:
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -33,7 +33,7 @@ To apply this pattern, the ISO needs to include:
 1. A [configuration file](https://rancher.github.io/elemental-toolkit/docs/customizing/general_configuration/)
    for the elemental client, describing at least the installation hooks location. This file is usually added to the ISO with path and name `/elemental/config.yaml`.
 
-2. The additional cloud-init files to be included into the installed system. They
+2. The additional `cloud-init` files to be included into the installed system. They
    allow to perform custom operations at boot time.
 
 3. The installation hooks evalutated at install time. They allow to perform custom operations

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -238,7 +238,7 @@ action of mounting those mountpoints. The Elemental OS `fstab` file is ephemeral
 dynamically created at boot time. That's why it doesn't exist during the installation and
 can't be used in an installation hook.
 
-The `overlay/oem/lvm_volumes_hook.yaml` could something as simple as:
+Here's an example of `overlay/oem/lvm_volumes_hook.yaml`:
 
 ```yaml showLineNumbers
 name: "Mount LVM volumes"

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -162,7 +162,7 @@ Note the installation hooks only cover installation procedures, for upgrades equ
 
 ### Adding extra LVM volume group disks during the installation
 
-This example is covering the case the host has multiple disks, some of them used
+This example is covering the setup of an host with multiple disks and some of them used
 as part of an LVM setup.
 
 In this particular case we will assume a host includes three disks (`/dev/sda`, `/dev/sdb`

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -93,7 +93,7 @@ According to that, the example above is expected to include the `/oem/custom_con
 
 #### Installation hooks
 
-[Elemental client](https://github.com/rancher/elemental-cli) `install`, `upgrade` and `reset` procedures include three different hooks:
+[Elemental client](https://github.com/rancher/elemental-cli) `install`, `upgrade` and `reset` procedures include four different hooks:
 
 * `before-install`: executed after all partition mountpoints are set.
 * `after-install-chroot`: executed after deploying the OS image and before unmounting the associated loop filesystem image. Runs chrooted to the OS image.

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -198,7 +198,6 @@ cloud-init-paths:
   - "/run/initramfs/live/hooks"
 ```
 
-This is just to let Elemental client know where to find installation hooks.
 
 The installation hook `overlay/hooks/lvm_volumes_hook.yaml` could be as:
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -65,8 +65,8 @@ to be added to the installation data into the MachineRegistration resource. More
 the `config-urls` field is used for this exact purpose. See [MachineRegistration reference](/machineregistration-reference) page.
 
 `config-urls` is a list of string literals where each item is an HTTP URL or a local path pointing to a
-cloud-init file or a local path of a cloud init file. Note the local path is evaluated during
-the installation, hence the local path must exist within the installation media, commonly an ISO image.
+cloud-init file. The local path is evaluated during
+the installation, hence it must exists within the installation media, commonly an ISO image.
 
 Since in Elemental Teal live systems the ISO root is mounted at `/run/initramfs/live`,
 the local paths for `config-url` in MachineRegistrations are likely to point there.

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -58,7 +58,7 @@ The above example assumes there is a `/hooks` folder in ISO root including
 the hook yaml files. Note the `/run/initramfs/live` prefix is the mount point
 of the ISO filesystem of the Elemental Live ISO.
 
-#### Adding additional cloud-init files witin the installed OS
+#### Adding additional cloud-init files within the installed OS
 
 In order to include additional cloud-init files during the installation they need
 to be added to the installation data into the MachineRegistration resource. More specific


### PR DESCRIPTION
This PR aims to improve the custom installation process and adds a new example on how to setup LVM volumes during the install which will be later on mounted at boot by default.

Signed-off-by: David Cassany <dcassany@suse.com>