### PR TITLE
Add creation of custom bootable install media

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -285,7 +285,7 @@ show case how this could be added:
 
 ```docker showLineNumbers
 # The version of Elemental to modify
-FROM registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-node-image/5.3:VERSION
+FROM registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-node-image/5.3:VERSION
 
 # Custom commands
 RUN rpm --import <repo-signing-key-url> && \
@@ -325,7 +325,7 @@ Elemental Teal leverages container images to build its root filesystems; therefo
 to use it in a multi-stage environment to create custom bootable media that bundles a custom container image.
 
 ```docker showLineNumbers
-FROM registry.opensuse.org/isv/rancher/elemental/teal53/15.4/rancher/elemental-node-image/5.3:latest as os
+FROM registry.opensuse.org/isv/rancher/elemental/stable/teal53/15.4/rancher/elemental-node-image/5.3:latest as os
 
 # Check the section on remastering a custom docker image
 


### PR DESCRIPTION
Users will be able to create custom images to customize the boot process; this includes:
- Custom or extra modules that are needed during boot.
- Embed custom configuration 
- Any other patching of the initially booted operating system 

This will also make it easier to roll out custom builds in air-gapped scenarios. 