### PR TITLE
Make registration-tpm.yaml visible

### DIFF
--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -1,3 +1,10 @@
+---
+sidebar_label: Trusted Platform Module (TPM)
+title: ''
+---
+
+import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+
 # Trusted Platform Module 2.0 (TPM)
 
 Trusted Platform Module (TPM, also known as ISO/IEC 11889) is an international standard for a secure cryptoprocessor, a dedicated microcontroller designed to secure hardware through integrated cryptographic keys. The term can also refer to a chip conforming to the standard.
@@ -40,6 +47,4 @@ so the seed used for the TPM emulation is randomized per machine. Otherwise, you
 one to be registered will be valid.
 :::
 
-```yaml title="registration-tpm.yaml" showLineNumbers
---8<-- "examples/quickstart/registration-tpm.yaml"
-```
+<CodeBlock language="yaml" title="registration-tpm.yaml" showLineNumbers>{RegistrationTpm}</CodeBlock>

--- a/versioned_docs/version-stable/tpm.md
+++ b/versioned_docs/version-stable/tpm.md
@@ -1,3 +1,10 @@
+---
+sidebar_label: Trusted Platform Module (TPM)
+title: ''
+---
+
+import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+
 # Trusted Platform Module 2.0 (TPM)
 
 Trusted Platform Module (TPM, also known as ISO/IEC 11889) is an international standard for a secure cryptoprocessor, a dedicated microcontroller designed to secure hardware through integrated cryptographic keys. The term can also refer to a chip conforming to the standard.
@@ -40,6 +47,4 @@ so the seed used for the TPM emulation is randomized per machine. Otherwise, you
 one to be registered will be valid.
 :::
 
-```yaml title="registration-tpm.yaml" showLineNumbers
---8<-- "examples/quickstart/registration-tpm.yaml"
-```
+<CodeBlock language="yaml" title="registration-tpm.yaml" showLineNumbers>{RegistrationTpm}</CodeBlock>


### PR DESCRIPTION
The `registration-tpm.yaml` example wasn't visible.

Before

![tpm-example-before](https://user-images.githubusercontent.com/37742/217228515-29d170e9-7f68-48ea-9d02-271f2c75dc41.png)

After

![tpm-example-after](https://user-images.githubusercontent.com/37742/217228566-00b69c40-72d2-4ae7-8d30-334ab149deed.png)

Signed-off-by: Klaus Kämpf <kkaempf@suse.de>