### PR TITLE
Update hardware labels page

### DIFF
--- a/docs/hardwarelabels.md
+++ b/docs/hardwarelabels.md
@@ -3,38 +3,37 @@ sidebar_label: Hardware Labels
 title: ''
 ---
 
+import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware.yaml"
+
 ## Hardware Labels
-When a node is registered, the data is stored in the [inventory](inventory-management.md#machineinventory) with default labels and values relative to the node hardware.
+When a node is registered, hardware data is collected and made available to the MachineRegistration in the same way as [SMBIOS data](smbios.md).
 
-This data is used for easy identification and selection via a [MachineSelector](machineinventoryselectortemplate-reference.md).
+This data can be used for easy identification and selection via a [MachineSelector](machineinventoryselectortemplate-reference.md).
 
+The following are available for templating:
 
-The following labels are set up automatically:
-
-| Label                                           | Description                                                         |
-|-------------------------------------------------|---------------------------------------------------------------------|
-| elemental.cattle.io/TotalMemory                 | The total RAM memory in the node, expressed in bytes                |
-| elemental.cattle.io/CpuTotalCores               | Total CPU cores                                                     |
-| elemental.cattle.io/CpuTotalThreads             | Total CPU threads                                                   |
-| elemental.cattle.io/CpuVendor                   | CPU vendor                                                          |
-| elemental.cattle.io/CpuModel                    | CPU model                                                           |
-| elemental.cattle.io/GpuModel                    | GPU model (Only available if the node has an identifiable GPU)      |
-| elemental.cattle.io/GpuVendor                   | GPU vendor (Only available if the node has an identifiable GPU)     |
-| elemental.cattle.io/NetNumberInterfaces         | Number of network interfaces in the system                          |
-| elemental.cattle.io/NetIfaceX-Name              | Network interface name                                              |
-| elemental.cattle.io/NetIfaceX-Virtual           | Whether the Network Interface is a virtual one                      |
-| elemental.cattle.io/BlockTotal                  | Number of block devices in the system (includes DVD and USB drives) |
-| elemental.cattle.io/BlockDeviceX-Name           | Device name of the block device (i.e. sda, sr0, vda, etc...)        |
-| elemental.cattle.io/BlockDeviceX-Removable      | Whether this block device is removable (i.e. DVD)                   |
-| elemental.cattle.io/BlockDeviceX-Size           | Total space in this block device, expressed in bytes                |
-| elemental.cattle.io/BlockDeviceX-DriveType      | Drive type of this block device, see table below                    |
-| elemental.cattle.io/BlockDeviceX-ControllerType | Controller type for this block device connection, see table below   |
-
+| Label                                                       | Description                                                           |
+| ----------------------------------------------------------- | --------------------------------------------------------------------- |
+| ${System Data/Memory/Total Physical Bytes}                  | The total RAM memory in the node, expressed in bytes                  |
+| ${System Data/CPU/Total Cores}                              | Total CPU cores                                                       |
+| ${System Data/CPU/Total Threads}                            | Total CPU threads                                                     |
+| ${System Data/CPU/Vendor}                                   | CPU vendor                                                            |
+| ${System Data/CPU/Model}                                    | CPU model                                                             |
+| ${System Data/GPU/Vendor}                                   | GPU vendor (Only available if the node has an identifiable GPU)       |
+| ${System Data/GPU/Model}                                    | GPU model (Only available if the node has an identifiable GPU)        |
+| ${System Data/Network/Number Interfaces}                    | Number of network interfaces in the system                            |
+| ${System Data/Network/{Iface name}/Name}                    | Network interface name                                                |
+| ${System Data/Network/{Iface name}/IsVirtual}               | Boolean indicating virtual network interface                          |
+| ${System Data/Block Devices/Number Devices}                 | Number of block devices in the system (includes DVD and USB drives)   |
+| ${System Data/Block Devices/{Disk name}/Name}               | Device name of the block device (i.e. sda, sr0, vda, etc...)          |
+| ${System Data/Block Devices/{Disk name}/Removable}          | Whether this block device is removable (i.e. DVD)                     |
+| ${System Data/Block Devices/{Disk name}/Size}               | Total space in this block device, expressed in bytes                  |
+| ${System Data/Block Devices/{Disk name}/Drive Type}         | Drive type of this block device, see table below                      |
+| ${System Data/Block Devices/{Disk name}/Storage Controller} | Controller type for this block device connection, see table below     |
 
 :::info info
-On both `BlockDeviceX` and `NetIfaceX` the X indicates a number, as there could be more than one device. Numbers are just for enumeration purposes and have no relation with the underlying hardware.
+On both `Block Devices` and `Network` the device name is used as a sub-block, as there could be more than one device.
 :::
-
 
 ### Block device drive types
 
@@ -59,3 +58,7 @@ On both `BlockDeviceX` and `NetIfaceX` the X indicates a number, as there could 
 | virtio  | Virtualized storage controller/driver                          |
 | loop    | loop device                                                    |
 | Unknown | unknown controller type                                        |
+
+### Example MachineRegistration
+
+<CodeBlock language="yaml" title="registration example with smbios labels" showLineNumbers>{Registration}</CodeBlock>

--- a/examples/quickstart/registration-hardware.yaml
+++ b/examples/quickstart/registration-hardware.yaml
@@ -16,6 +16,6 @@ spec:
         debug: true
   machineInventoryLabels:
     elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
-    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
     elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
     elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/examples/quickstart/registration-hardware.yaml
+++ b/examples/quickstart/registration-hardware.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"


### PR DESCRIPTION
In the latest version the hardware labels are not set automatically anymore, but can instead be set in the same way as SMBIOS labels in the MachineRegistration.