### PR TITLE
Fix cluster.yaml example

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -123,6 +123,8 @@ As you can see this is a very simple selector that checks the key `location` for
 
 As you can see we are setting that our `machineConfigRef` is of Kind `MachineInventorySelectorTemplate` with the name `my-machine-selector`, which matches the selector we created.
 
+You can get more informations about some cluster options like [`machineGlobalConfig`](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#machineglobalconfig) or [`machineSelectorConfig`](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#machineselectorconfig) directly in Rancher Manager documentation.
+
 <Tabs>
 <TabItem value="normalRegistration" label="Registration" default>
 <CodeBlock language="yaml" title="registration.yaml" showLineNumbers>{Registration}</CodeBlock>

--- a/examples/quickstart/cluster.yaml
+++ b/examples/quickstart/cluster.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: fleet-default
 spec:
   rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
     machinePools:
       - controlPlaneRole: true
         etcdRole: true
@@ -16,4 +19,8 @@ spec:
         quantity: 1
         unhealthyNodeTimeout: 0s
         workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
   kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-stable/quickstart.md
+++ b/versioned_docs/version-stable/quickstart.md
@@ -90,6 +90,8 @@ As you can see this is a very simple selector that checks the key `location` for
 
 As you can see we are setting that our `machineConfigRef` is of Kind `MachineInventorySelectorTemplate` with the name `my-machine-selector`, which matches the selector we created.
 
+You can get more informations about some cluster options like [`machineGlobalConfig`](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#machineglobalconfig) or [`machineSelectorConfig`](https://ranchermanager.docs.rancher.com/reference-guides/cluster-configuration/rancher-server-configuration/rke2-cluster-configuration#machineselectorconfig) directly in Rancher Manager documentation.
+
 <CodeBlock language="yaml" title="registration.yaml" showLineNumbers>{Registration}</CodeBlock>
 
 This creates a `MachineRegistration` which will provide a unique URL which we will use with `elemental-register` to register


### PR DESCRIPTION
This is to allow application deployement from the Rancher UI.

See rancher/elemental#751 and rancher/elemental-operator#310 for more information.