### PR TITLE
Added versioning steps to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ This command starts a local development server and opens up a browser window. Mo
 yarn build
 ```
 
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
+This command generates static content into the `build` directory and can be served using any static contents hosting service with the following command:
+
+```console
+yarn serve
+```
 
 ## Deployment
 
@@ -31,3 +35,29 @@ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
 ```
 
 If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+
+## Docs versioning
+
+The versioning is done in two steps:
+
+1. Delete the entry `Stable` from the file `/versions.json`
+
+1. Copy the content from the `Next` version into `Stable`
+
+```console
+yarn run docusaurus docs:version Stable
+```
+
+### Check the versioning
+
+The versioning command will generate the following content:
+
+* The entry `Stable` will be added (again) to the `/versions.json` file
+
+* `/versioned_docs/version-Stable` will be updated with the `Next` content located in `/docs`
+
+* `/versioned_sidebars/version-Stable-sidebars.json` will be updated with the `Next` sidebar content located in `/sidebar.js`
+
+## Recommendations before creating a Pull Request
+
+Before creating a Pull Request for adding new docs or creating a new version, it's strongly encouraged to build the docs site [as described above](#build)


### PR DESCRIPTION
Added the steps needed to create a new version, or in this case, update the `Stable` version with the content from the `Next` version.

This update is only triggered when a new version of Elemental is released, so the docs are up-to-date.

Signed-off-by: Nuno do Carmo <nuno.carmo@suse.com>