### PR TITLE
Clarify 2.7.0 _or later_

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,12 @@ and available through the [openSUSE Registry](https://registry.opensuse.org/cgi-
 
 ### Elemental on x86-64 hardware
 
-Elemental Teal is production ready and fully supported on x86-64 with Rancher v2.7.0.
+Elemental Teal is production ready and fully supported on x86-64 starting with Rancher v2.7.0.
 
 ### Elemental on ARM hardware
 
 ARM (aarch64) is functional in the development version. ARM is currently only tested on Raspberry Pi 4 Model B with k3s 1.24.8 (or later). We welcome feedback !
+
 
 ### Elemental on other hardware
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,6 @@ Elemental Teal is production ready and fully supported on x86-64 starting with R
 
 ARM (aarch64) is functional in the development version. ARM is currently only tested on Raspberry Pi 4 Model B with k3s 1.24.8 (or later). We welcome feedback !
 
-
 ### Elemental on other hardware
 
 Elemental is currently targeting 'edge' scenarios and does therefore not support other hardware.

--- a/docs/partials/_quickstart-prereqs.md
+++ b/docs/partials/_quickstart-prereqs.md
@@ -1,6 +1,6 @@
 ## Prerequisites
 
-* A Rancher server (v2.7.0) configured (server-url set)
+* A Rancher server (v2.7.0 or later) configured (server-url set)
   * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm/#add-tpm-module-to-virtual-machine)

--- a/versioned_docs/version-Stable/index.md
+++ b/versioned_docs/version-Stable/index.md
@@ -34,7 +34,7 @@ and available through the [openSUSE Registry](https://registry.opensuse.org/cgi-
 
 ### Elemental on x86-64 hardware
 
-Elemental Teal is production ready and fully supported on x86-64 with Rancher v2.7.0.
+Elemental Teal is production ready and fully supported on x86-64 starting with Rancher v2.7.0.
 
 ### Elemental on ARM hardware
 

--- a/versioned_docs/version-Stable/partials/_quickstart-prereqs.md
+++ b/versioned_docs/version-Stable/partials/_quickstart-prereqs.md
@@ -1,6 +1,6 @@
 ## Prerequisites
 
-* A Rancher server (v2.7.0) configured (server-url set)
+* A Rancher server (v2.7.0 or later) configured (server-url set)
   * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm/#add-tpm-module-to-virtual-machine)


### PR DESCRIPTION
Documentation only lists 2.7.0 while we're (almost) at 2.7.5 already.

Clarify that Elemental runs on Rancher 2.7.0 or later.