### PR TITLE
Sidebar menus collapsed configuration

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -30,7 +30,7 @@ const sidebars = {
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Install/Upgrade",
       "items": [
         "installation",
@@ -42,7 +42,7 @@ const sidebars = {
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Reference",
       "items": [
         "cloud-config-reference",
@@ -59,7 +59,7 @@ const sidebars = {
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Operator",
       "items": [
         "inventory-management",
@@ -68,7 +68,7 @@ const sidebars = {
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Backup",
       "items": [
         "backup",
@@ -78,7 +78,7 @@ const sidebars = {
     {
       type: 'category',
       collapsible: true,
-      collapsed: false,
+      collapsed: true,
       label: 'How to',
       items: [
         'wifi',
@@ -90,13 +90,13 @@ const sidebars = {
     {
       type: 'category',
       collapsible: true,
-      collapsed: false,
+      collapsed: true,
       label: 'Troubleshooting',
       items: [
         {
           "type": "category",
           "collapsible": true,
-          "collapsed": false,
+          "collapsed": true,
           "label": "Rancher",
           "items": [
             "troubleshooting-rancher-upgrades",
@@ -105,7 +105,7 @@ const sidebars = {
         {
           "type": "category",
           "collapsible": true,
-          "collapsed": false,
+          "collapsed": true,
           "label": "Restore",
           "items": [
             "troubleshooting-restore",
@@ -114,7 +114,7 @@ const sidebars = {
         {
           "type": "category",
           "collapsible": true,
-          "collapsed": false,
+          "collapsed": true,
           "label": "Upgrade",
           "items": [
             "troubleshooting-upgrade"

--- a/versioned_sidebars/version-1.2-sidebars.json
+++ b/versioned_sidebars/version-1.2-sidebars.json
@@ -15,7 +15,7 @@
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Install/Upgrade",
       "items": [
         "installation",
@@ -27,7 +27,7 @@
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Reference",
       "items": [
         "cloud-config-reference",
@@ -44,7 +44,7 @@
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Operator",
       "items": [
         "inventory-management"
@@ -53,7 +53,7 @@
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Backup",
       "items": [
         "backup",
@@ -63,7 +63,7 @@
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "How to",
       "items": [
         "wifi",
@@ -75,13 +75,13 @@
     {
       "type": "category",
       "collapsible": true,
-      "collapsed": false,
+      "collapsed": true,
       "label": "Troubleshooting",
       "items": [
         {
           "type": "category",
           "collapsible": true,
-          "collapsed": false,
+          "collapsed": true,
           "label": "Rancher",
           "items": [
             "troubleshooting-rancher-upgrades"
@@ -90,7 +90,7 @@
         {
           "type": "category",
           "collapsible": true,
-          "collapsed": false,
+          "collapsed": true,
           "label": "Restore",
           "items": [
             "troubleshooting-restore"
@@ -99,7 +99,7 @@
         {
           "type": "category",
           "collapsible": true,
-          "collapsed": false,
+          "collapsed": true,
           "label": "Upgrade",
           "items": [
             "troubleshooting-upgrade"


### PR DESCRIPTION
All the menus except for `Quickstarts` are now collapsed by default.

Both current and next version's sidebars has been updated.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com