### PR TITLE
Fix certificates path

### DIFF
--- a/docs/custom-certificate.md
+++ b/docs/custom-certificate.md
@@ -18,14 +18,14 @@ container image instead.
 In order to install a custom certificate on SLE Micro for Rancher we
 need to
 
-* copy the `.pem` file to `/etc/ssl/certs`
+* copy the `.pem` file to `/etc/pki/trust/anchors/`
 * run `update-ca-certificates`
 
 The respective `cloud-config` snippet looks like this:
 
-```
+```yaml
 write_files:
-  - path: /etc/ssl/certs/my-custom-certificate.pem
+  - path: /etc/pki/trust/anchors/my-custom-certificate.pem
     permission: 0444
     content: |-
       -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
`/etc/ssl/certs` is going to be rewritten by `update-ca-certificates` command.  

`/usr/share/local/ca-certificates` is going to be read-only by default.  

We can use `/usr/share/pki/trust/anchors/ ` or `/etc/pki/trust/anchors/`.