### PR TITLE
Add canonical links to page headers

### DIFF
--- a/docs/airgap.md
+++ b/docs/airgap.md
@@ -3,6 +3,10 @@ sidebar_label: Air-Gapped Installation
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/airgap"/>
+</head>
+
 ## Install Elemental in an Air-Gapped Environment
 
 ### Assumptions

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,10 @@ sidebar_label: Architecture
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/architecture"/>
+</head>
+
 # Architecture
 
 The Elemental stack can be divided in two main parts: the Elemental OS, an immutable and customizable OS which comprises the tools and the steps needed to prepare the Cloud Native OS image and perform the actual OS installation on the host, and the <Vars name="elemental_operator_name" />, that allows central management of the Elemental OS via Rancher, the Kubernetes way.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -3,6 +3,10 @@ sidebar_label: Backup
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/backup"/>
+</head>
+
 # Backup
 
 Since Elemental runs as part of Rancher, the Elemental resources are bundled in the Rancher backup.  

--- a/docs/cloud-config-reference.md
+++ b/docs/cloud-config-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Cloud-config reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/cloud-config-reference"/>
+</head>
+
 # Cloud-config Reference
 
 All custom configuration applied on top of a fresh deployment should come

--- a/docs/cluster-reference.md
+++ b/docs/cluster-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Cluster reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
+</head>
+
 import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference

--- a/docs/custom-certificate.md
+++ b/docs/custom-certificate.md
@@ -3,6 +3,10 @@ sidebar_label: Add a custom certificate
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/custom-certificate"/>
+</head>
+
 
 ### How to add a custom certificate
 

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -3,6 +3,10 @@ sidebar_label: Customize Elemental Install
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/customizing"/>
+</head>
+
 # Customize Elemental Install
 
 Elemental Teal images can be customized in different ways.

--- a/docs/elemental-plans.md
+++ b/docs/elemental-plans.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental plans
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elemental-plans"/>
+</head>
+
 ## Introduction
 
 Elemental uses the [Rancher System Agent](https://github.com/rancher/system-agent), renamed to Elemental System Agent, to initially bootstrap the node with a simple plan.

--- a/docs/elemental_behind_proxy.md
+++ b/docs/elemental_behind_proxy.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental behind proxy
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
+</head>
+
 import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
 import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
 import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"

--- a/docs/elementaloperatorchart-reference.md
+++ b/docs/elementaloperatorchart-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental Operator Helm Chart
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elementaloperatorchart-reference"/>
+</head>
+
 # Elemental Operator Helm Chart
 
 The <Vars name="elemental_operator_name" link="elemental_operator_url" /> is responsible for managing the Elemental versions and maintaining a machine inventory to assist with edge or bare metal installations.

--- a/docs/hardwarelabels.md
+++ b/docs/hardwarelabels.md
@@ -3,6 +3,10 @@ sidebar_label: Hardware Labels
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
+</head>
+
 import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware.yaml"
 
 ## Hardware Labels

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@ sidebar_label: Overview
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com"/>
+</head>
+
 # Overview
 
 Elemental is a software stack enabling centralized, full cloud-native OS management with Kubernetes.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,6 +3,10 @@ sidebar_label: Installation
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/installation"/>
+</head>
+
 # Installation
 
 ## Overview

--- a/docs/inventory-management.md
+++ b/docs/inventory-management.md
@@ -4,6 +4,10 @@ title: ''
 version_badge: '1.3.0'
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/inventory-management"/>
+</head>
+
 ## Inventory Management
 
 The Elemental operator can hold an inventory of machines and

--- a/docs/kubernetesversions.md
+++ b/docs/kubernetesversions.md
@@ -3,6 +3,10 @@ sidebar_label: Kubernetes versions
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/kubernetesversions"/>
+</head>
+
 ## Valid Versions
 
 The list of valid versions for the `kubernetesVersion` field can be determined

--- a/docs/machineinventoryselectortemplate-reference.md
+++ b/docs/machineinventoryselectortemplate-reference.md
@@ -3,6 +3,10 @@ sidebar_label: MachineInventorySelectorTemplate reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/machineinventoryselectortemplate-reference"/>
+</head>
+
 # MachineInventorySelectorTemplate reference
 
 The MachineInventorySelectorTemplate is the resource responsible of defining the matching criteria to pair an inventoried machine with a Cluster resource.

--- a/docs/machineregistration-reference.md
+++ b/docs/machineregistration-reference.md
@@ -3,6 +3,10 @@ sidebar_label: MachineRegistration reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/machineregistration-reference"/>
+</head>
+
 # MachineRegistration reference
 
 The MachineRegistration resource is the responsible of defining a machine registration end point. Once created it generates a registration URL used by nodes to register so they are inventoried.

--- a/docs/quickstart-cli.md
+++ b/docs/quickstart-cli.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental the command line way
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
+</head>
+
 import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"

--- a/docs/quickstart-ui.md
+++ b/docs/quickstart-ui.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental the visual way
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
+</head>
+
 import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"

--- a/docs/rancher-vmware.md
+++ b/docs/rancher-vmware.md
@@ -3,6 +3,10 @@ sidebar_label: How to use Elemental with Rancher and VMware
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/rancher-vmware"/>
+</head>
+
 # How to use Elemental with Rancher and VMware
 
 ## Excerpt

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -3,6 +3,10 @@ sidebar_label: Release Notes
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/release-notes"/>
+</head>
+
 # Release Notes
 
 The Elemental project stack is made of various components such as the `Operator` and `UI` for example.

--- a/docs/removable-device-cloudconfig.md
+++ b/docs/removable-device-cloudconfig.md
@@ -3,6 +3,10 @@ sidebar_label: Include cloud-config from removable devices
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/removable-device-cloudconfig"/>
+</head>
+
 
 ### How to include cloud-config files from removable devices
 

--- a/docs/reset.md
+++ b/docs/reset.md
@@ -4,6 +4,10 @@ title: ''
 version_badge: '1.3.0'
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/reset"/>
+</head>
+
 ## Machine Reset
 
 There are two ways to reset Elemental machines to their original state or decommission them:

--- a/docs/restore.md
+++ b/docs/restore.md
@@ -3,6 +3,10 @@ sidebar_label: Restore
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/restore"/>
+</head>
+
 # Restore
 
 Follow this guide to restore an Elemental configuration from a backup with Rancher.

--- a/docs/seedimage-reference.md
+++ b/docs/seedimage-reference.md
@@ -3,6 +3,10 @@ sidebar_label: SeedImage reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/seedimage-reference"/>
+</head>
+
 # SeedImage reference
 
 A `SeedImage` resource allows to build an ISO that can be used to install Elemental onto a node.  

--- a/docs/smbios.md
+++ b/docs/smbios.md
@@ -3,6 +3,10 @@ sidebar_label: Smbios
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
+</head>
+
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 
 ## Introduction

--- a/docs/tpm.md
+++ b/docs/tpm.md
@@ -3,6 +3,10 @@ sidebar_label: Trusted Platform Module (TPM)
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
+</head>
+
 import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)

--- a/docs/troubleshooting-rancher-upgrades.md
+++ b/docs/troubleshooting-rancher-upgrades.md
@@ -3,6 +3,10 @@ sidebar_label: Rancher upgrades
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-rancher-upgrades"/>
+</head>
+
 # Troubleshooting Rancher upgrades
 
 :::warning warning

--- a/docs/troubleshooting-reset.md
+++ b/docs/troubleshooting-reset.md
@@ -3,6 +3,10 @@ sidebar_label: Reset
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-reset"/>
+</head>
+
 # Troubleshooting reset
 
 Each `MachineInventory` with the `elemental.cattle.io/resettable: "true"` annotation will trigger the execution of a reset plan, upon deletion.  

--- a/docs/troubleshooting-restore.md
+++ b/docs/troubleshooting-restore.md
@@ -3,6 +3,10 @@ sidebar_label: Restore
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-restore"/>
+</head>
+
 # Troubleshooting restore
 
 :::warning warning

--- a/docs/troubleshooting-upgrade.md
+++ b/docs/troubleshooting-upgrade.md
@@ -3,6 +3,10 @@ sidebar_label: Upgrade
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-upgrade"/>
+</head>
+
 # Troubleshooting upgrade
 
 ![Upgrade Flow](images/troubleshooting-upgrade.png)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -3,6 +3,10 @@ sidebar_label: Upgrade
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
+</head>
+
 import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
 import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
 import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"

--- a/docs/wifi.md
+++ b/docs/wifi.md
@@ -3,6 +3,10 @@ sidebar_label: Configure Wi-Fi
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/wifi"/>
+</head>
+
 
 ### How to configure Wi-Fi
 

--- a/versioned_docs/version-1.2/architecture.md
+++ b/versioned_docs/version-1.2/architecture.md
@@ -3,6 +3,10 @@ sidebar_label: Architecture
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/architecture"/>
+</head>
+
 # Architecture
 
 The Elemental stack can be divided in two main parts: the Elemental OS, an immutable and customizable OS which comprises the tools and the steps needed to prepare the Cloud Native OS image and perform the actual OS installation on the host, and the <Vars name="elemental_operator_name" />, that allows central management of the Elemental OS via Rancher, the Kubernetes way.

--- a/versioned_docs/version-1.2/backup.md
+++ b/versioned_docs/version-1.2/backup.md
@@ -3,6 +3,10 @@ sidebar_label: Backup
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/backup"/>
+</head>
+
 # Backup
 
 Since Elemental runs as part of Rancher, the Elemental resources are bundled in the Rancher backup.  

--- a/versioned_docs/version-1.2/cloud-config-reference.md
+++ b/versioned_docs/version-1.2/cloud-config-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Cloud-config reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/cloud-config-reference"/>
+</head>
+
 # Cloud-config Reference
 
 All custom configuration applied on top of a fresh deployment should come

--- a/versioned_docs/version-1.2/cluster-reference.md
+++ b/versioned_docs/version-1.2/cluster-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Cluster reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
+</head>
+
 import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference

--- a/versioned_docs/version-1.2/custom-certificate.md
+++ b/versioned_docs/version-1.2/custom-certificate.md
@@ -3,6 +3,9 @@ sidebar_label: Add a custom certificate
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/custom-certificate"/>
+</head>
 
 ### How to add a custom certificate
 

--- a/versioned_docs/version-1.2/customizing.md
+++ b/versioned_docs/version-1.2/customizing.md
@@ -3,6 +3,10 @@ sidebar_label: Customize Elemental Install
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/customizing"/>
+</head>
+
 # Customize Elemental Install
 
 Elemental Teal images can be customized in different ways.

--- a/versioned_docs/version-1.2/elemental-plans.md
+++ b/versioned_docs/version-1.2/elemental-plans.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental plans
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elemental-plans"/>
+</head>
+
 ## Introduction
 
 Elemental uses the [Rancher System Agent](https://github.com/rancher/system-agent), renamed to Elemental System Agent, to initially bootstrap the node with a simple plan.

--- a/versioned_docs/version-1.2/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.2/elemental_behind_proxy.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental behind proxy
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
+</head>
+
 import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
 import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
 import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"

--- a/versioned_docs/version-1.2/elementaloperatorchart-reference.md
+++ b/versioned_docs/version-1.2/elementaloperatorchart-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental Operator Helm Chart
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elementaloperatorchart-reference"/>
+</head>
+
 # Elemental Operator Helm Chart
 
 The <Vars name="elemental_operator_name" link="elemental_operator_url" /> is responsible for managing the Elemental versions and maintaining a machine inventory to assist with edge or bare metal installations.

--- a/versioned_docs/version-1.2/hardwarelabels.md
+++ b/versioned_docs/version-1.2/hardwarelabels.md
@@ -3,6 +3,10 @@ sidebar_label: Hardware Labels
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
+</head>
+
 import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware.yaml"
 
 ## Hardware Labels

--- a/versioned_docs/version-1.2/index.md
+++ b/versioned_docs/version-1.2/index.md
@@ -4,6 +4,10 @@ sidebar_label: Overview
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com"/>
+</head>
+
 # Overview
 
 Elemental is a software stack enabling centralized, full cloud-native OS management with Kubernetes.

--- a/versioned_docs/version-1.2/installation.md
+++ b/versioned_docs/version-1.2/installation.md
@@ -3,6 +3,10 @@ sidebar_label: Installation
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/installation"/>
+</head>
+
 # Installation
 
 ## Overview

--- a/versioned_docs/version-1.2/inventory-management.md
+++ b/versioned_docs/version-1.2/inventory-management.md
@@ -4,6 +4,10 @@ title: ''
 version_badge: '1.3.0'
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/inventory-management"/>
+</head>
+
 ## Inventory Management
 
 The Elemental operator can hold an inventory of machines and

--- a/versioned_docs/version-1.2/kubernetesversions.md
+++ b/versioned_docs/version-1.2/kubernetesversions.md
@@ -3,6 +3,10 @@ sidebar_label: Kubernetes versions
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/kubernetesversions"/>
+</head>
+
 ## Valid Versions
 
 The list of valid versions for the `kubernetesVersion` field can be determined

--- a/versioned_docs/version-1.2/machineinventoryselectortemplate-reference.md
+++ b/versioned_docs/version-1.2/machineinventoryselectortemplate-reference.md
@@ -3,6 +3,10 @@ sidebar_label: MachineInventorySelectorTemplate reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/machineinventoryselectortemplate-reference"/>
+</head>
+
 # MachineInventorySelectorTemplate reference
 
 The MachineInventorySelectorTemplate is the resource responsible of defining the matching criteria to pair an inventoried machine with a Cluster resource.

--- a/versioned_docs/version-1.2/machineregistration-reference.md
+++ b/versioned_docs/version-1.2/machineregistration-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Machineregistration reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/machineregistration-reference"/>
+</head>
+
 # MachineRegistration reference
 
 The MachineRegistration resource is the responsible of defining a machine registration end point. Once created it generates a registration URL used by nodes to register so they are inventoried.

--- a/versioned_docs/version-1.2/quickstart-cli.md
+++ b/versioned_docs/version-1.2/quickstart-cli.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental the command line way
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
+</head>
+
 import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"

--- a/versioned_docs/version-1.2/quickstart-ui.md
+++ b/versioned_docs/version-1.2/quickstart-ui.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental the visual way
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
+</head>
+
 import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"

--- a/versioned_docs/version-1.2/rancher-vmware.md
+++ b/versioned_docs/version-1.2/rancher-vmware.md
@@ -3,6 +3,10 @@ sidebar_label: How to use Elemental with Rancher and VMware
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/rancher-vmware"/>
+</head>
+
 # How to use Elemental with Rancher and VMware
 
 ## Excerpt

--- a/versioned_docs/version-1.2/release-notes.md
+++ b/versioned_docs/version-1.2/release-notes.md
@@ -3,6 +3,10 @@ sidebar_label: Release Notes
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/release-notes"/>
+</head>
+
 # Release Notes
 
 The Elemental project stack is made of various components such as the `Operator` and `UI` for example.

--- a/versioned_docs/version-1.2/removable-device-cloudconfig.md
+++ b/versioned_docs/version-1.2/removable-device-cloudconfig.md
@@ -3,6 +3,9 @@ sidebar_label: Include cloud-config from removable devices
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/removable-device-cloudconfig"/>
+</head>
 
 ### How to include cloud-config files from removable devices
 

--- a/versioned_docs/version-1.2/restore.md
+++ b/versioned_docs/version-1.2/restore.md
@@ -3,6 +3,10 @@ sidebar_label: Restore
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/restore"/>
+</head>
+
 # Restore
 
 Follow this guide to restore an Elemental configuration from a backup with Rancher.

--- a/versioned_docs/version-1.2/seedimage-reference.md
+++ b/versioned_docs/version-1.2/seedimage-reference.md
@@ -3,6 +3,10 @@ sidebar_label: SeedImage reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/seedimage-reference"/>
+</head>
+
 # SeedImage reference
 
 A `SeedImage` resource allows to build an ISO that can be used to install Elemental onto a node.  

--- a/versioned_docs/version-1.2/smbios.md
+++ b/versioned_docs/version-1.2/smbios.md
@@ -3,6 +3,10 @@ sidebar_label: Smbios
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
+</head>
+
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 
 ## Introduction

--- a/versioned_docs/version-1.2/tpm.md
+++ b/versioned_docs/version-1.2/tpm.md
@@ -3,6 +3,10 @@ sidebar_label: Trusted Platform Module (TPM)
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
+</head>
+
 import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)

--- a/versioned_docs/version-1.2/troubleshooting-rancher-upgrades.md
+++ b/versioned_docs/version-1.2/troubleshooting-rancher-upgrades.md
@@ -3,6 +3,10 @@ sidebar_label: Rancher upgrades
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-rancher-upgrades"/>
+</head>
+
 # Troubleshooting Rancher upgrades
 
 :::warning warning

--- a/versioned_docs/version-1.2/troubleshooting-restore.md
+++ b/versioned_docs/version-1.2/troubleshooting-restore.md
@@ -3,6 +3,10 @@ sidebar_label: Restore
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-restore"/>
+</head>
+
 # Troubleshooting restore
 
 :::warning warning

--- a/versioned_docs/version-1.2/troubleshooting-upgrade.md
+++ b/versioned_docs/version-1.2/troubleshooting-upgrade.md
@@ -3,6 +3,10 @@ sidebar_label: Upgrade
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-upgrade"/>
+</head>
+
 # Troubleshooting upgrade
 
 ![Upgrade Flow](images/troubleshooting-upgrade.png)

--- a/versioned_docs/version-1.2/upgrade.md
+++ b/versioned_docs/version-1.2/upgrade.md
@@ -3,6 +3,10 @@ sidebar_label: Upgrade
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
+</head>
+
 import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
 import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
 import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"

--- a/versioned_docs/version-1.2/wifi.md
+++ b/versioned_docs/version-1.2/wifi.md
@@ -3,6 +3,9 @@ sidebar_label: Configure Wi-Fi
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/wifi"/>
+</head>
 
 ### How to configure Wi-Fi
 

--- a/versioned_docs/version-1.3/architecture.md
+++ b/versioned_docs/version-1.3/architecture.md
@@ -3,6 +3,10 @@ sidebar_label: Architecture
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/architecture"/>
+</head>
+
 # Architecture
 
 The Elemental stack can be divided in two main parts: the Elemental OS, an immutable and customizable OS which comprises the tools and the steps needed to prepare the Cloud Native OS image and perform the actual OS installation on the host, and the <Vars name="elemental_operator_name" />, that allows central management of the Elemental OS via Rancher, the Kubernetes way.

--- a/versioned_docs/version-1.3/backup.md
+++ b/versioned_docs/version-1.3/backup.md
@@ -3,6 +3,10 @@ sidebar_label: Backup
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/backup"/>
+</head>
+
 # Backup
 
 Since Elemental runs as part of Rancher, the Elemental resources are bundled in the Rancher backup.  

--- a/versioned_docs/version-1.3/cloud-config-reference.md
+++ b/versioned_docs/version-1.3/cloud-config-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Cloud-config reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/cloud-config-reference"/>
+</head>
+
 # Cloud-config Reference
 
 All custom configuration applied on top of a fresh deployment should come

--- a/versioned_docs/version-1.3/cluster-reference.md
+++ b/versioned_docs/version-1.3/cluster-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Cluster reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
+</head>
+
 import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference

--- a/versioned_docs/version-1.3/custom-certificate.md
+++ b/versioned_docs/version-1.3/custom-certificate.md
@@ -3,6 +3,10 @@ sidebar_label: Add a custom certificate
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/custom-certificate"/>
+</head>
+
 
 ### How to add a custom certificate
 

--- a/versioned_docs/version-1.3/customizing.md
+++ b/versioned_docs/version-1.3/customizing.md
@@ -3,6 +3,10 @@ sidebar_label: Customize Elemental Install
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/customizing"/>
+</head>
+
 # Customize Elemental Install
 
 Elemental Teal images can be customized in different ways.

--- a/versioned_docs/version-1.3/elemental-plans.md
+++ b/versioned_docs/version-1.3/elemental-plans.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental plans
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elemental-plans"/>
+</head>
+
 ## Introduction
 
 Elemental uses the [Rancher System Agent](https://github.com/rancher/system-agent), renamed to Elemental System Agent, to initially bootstrap the node with a simple plan.

--- a/versioned_docs/version-1.3/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.3/elemental_behind_proxy.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental behind proxy
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
+</head>
+
 import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
 import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
 import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"

--- a/versioned_docs/version-1.3/elementaloperatorchart-reference.md
+++ b/versioned_docs/version-1.3/elementaloperatorchart-reference.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental Operator Helm Chart
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/elementaloperatorchart-reference"/>
+</head>
+
 # Elemental Operator Helm Chart
 
 The <Vars name="elemental_operator_name" link="elemental_operator_url" /> is responsible for managing the Elemental versions and maintaining a machine inventory to assist with edge or bare metal installations.

--- a/versioned_docs/version-1.3/hardwarelabels.md
+++ b/versioned_docs/version-1.3/hardwarelabels.md
@@ -3,6 +3,10 @@ sidebar_label: Hardware Labels
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
+</head>
+
 import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware.yaml"
 
 ## Hardware Labels

--- a/versioned_docs/version-1.3/index.md
+++ b/versioned_docs/version-1.3/index.md
@@ -4,6 +4,10 @@ sidebar_label: Overview
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com"/>
+</head>
+
 # Overview
 
 Elemental is a software stack enabling centralized, full cloud-native OS management with Kubernetes.

--- a/versioned_docs/version-1.3/installation.md
+++ b/versioned_docs/version-1.3/installation.md
@@ -3,6 +3,10 @@ sidebar_label: Installation
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/installation"/>
+</head>
+
 # Installation
 
 ## Overview

--- a/versioned_docs/version-1.3/inventory-management.md
+++ b/versioned_docs/version-1.3/inventory-management.md
@@ -4,6 +4,10 @@ title: ''
 version_badge: '1.3.0'
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/inventory-management"/>
+</head>
+
 ## Inventory Management
 
 The Elemental operator can hold an inventory of machines and

--- a/versioned_docs/version-1.3/kubernetesversions.md
+++ b/versioned_docs/version-1.3/kubernetesversions.md
@@ -3,6 +3,10 @@ sidebar_label: Kubernetes versions
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/kubernetesversions"/>
+</head>
+
 ## Valid Versions
 
 The list of valid versions for the `kubernetesVersion` field can be determined

--- a/versioned_docs/version-1.3/machineinventoryselectortemplate-reference.md
+++ b/versioned_docs/version-1.3/machineinventoryselectortemplate-reference.md
@@ -3,6 +3,10 @@ sidebar_label: MachineInventorySelectorTemplate reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/machineinventoryselectortemplate-reference"/>
+</head>
+
 # MachineInventorySelectorTemplate reference
 
 The MachineInventorySelectorTemplate is the resource responsible of defining the matching criteria to pair an inventoried machine with a Cluster resource.

--- a/versioned_docs/version-1.3/machineregistration-reference.md
+++ b/versioned_docs/version-1.3/machineregistration-reference.md
@@ -3,6 +3,10 @@ sidebar_label: MachineRegistration reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/machineregistration-reference"/>
+</head>
+
 # MachineRegistration reference
 
 The MachineRegistration resource is the responsible of defining a machine registration end point. Once created it generates a registration URL used by nodes to register so they are inventoried.

--- a/versioned_docs/version-1.3/quickstart-cli.md
+++ b/versioned_docs/version-1.3/quickstart-cli.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental the command line way
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
+</head>
+
 import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"

--- a/versioned_docs/version-1.3/quickstart-ui.md
+++ b/versioned_docs/version-1.3/quickstart-ui.md
@@ -3,6 +3,10 @@ sidebar_label: Elemental the visual way
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
+</head>
+
 import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"

--- a/versioned_docs/version-1.3/rancher-vmware.md
+++ b/versioned_docs/version-1.3/rancher-vmware.md
@@ -3,6 +3,10 @@ sidebar_label: How to use Elemental with Rancher and VMware
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/rancher-vmware"/>
+</head>
+
 # How to use Elemental with Rancher and VMware
 
 ## Excerpt

--- a/versioned_docs/version-1.3/release-notes.md
+++ b/versioned_docs/version-1.3/release-notes.md
@@ -3,6 +3,10 @@ sidebar_label: Release Notes
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/release-notes"/>
+</head>
+
 # Release Notes
 
 The Elemental project stack is made of various components such as the `Operator` and `UI` for example.

--- a/versioned_docs/version-1.3/removable-device-cloudconfig.md
+++ b/versioned_docs/version-1.3/removable-device-cloudconfig.md
@@ -3,6 +3,10 @@ sidebar_label: Include cloud-config from removable devices
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/removable-device-cloudconfig"/>
+</head>
+
 
 ### How to include cloud-config files from removable devices
 

--- a/versioned_docs/version-1.3/reset.md
+++ b/versioned_docs/version-1.3/reset.md
@@ -4,6 +4,10 @@ title: ''
 version_badge: '1.3.0'
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/reset"/>
+</head>
+
 ## Machine Reset
 
 There are two ways to reset Elemental machines to their original state or decommission them:

--- a/versioned_docs/version-1.3/restore.md
+++ b/versioned_docs/version-1.3/restore.md
@@ -3,6 +3,10 @@ sidebar_label: Restore
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/restore"/>
+</head>
+
 # Restore
 
 Follow this guide to restore an Elemental configuration from a backup with Rancher.

--- a/versioned_docs/version-1.3/seedimage-reference.md
+++ b/versioned_docs/version-1.3/seedimage-reference.md
@@ -3,6 +3,10 @@ sidebar_label: SeedImage reference
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/seedimage-reference"/>
+</head>
+
 # SeedImage reference
 
 A `SeedImage` resource allows to build an ISO that can be used to install Elemental onto a node.  

--- a/versioned_docs/version-1.3/smbios.md
+++ b/versioned_docs/version-1.3/smbios.md
@@ -3,6 +3,10 @@ sidebar_label: Smbios
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
+</head>
+
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 
 ## Introduction

--- a/versioned_docs/version-1.3/tpm.md
+++ b/versioned_docs/version-1.3/tpm.md
@@ -3,6 +3,10 @@ sidebar_label: Trusted Platform Module (TPM)
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
+</head>
+
 import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)

--- a/versioned_docs/version-1.3/troubleshooting-rancher-upgrades.md
+++ b/versioned_docs/version-1.3/troubleshooting-rancher-upgrades.md
@@ -3,6 +3,10 @@ sidebar_label: Rancher upgrades
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-rancher-upgrades"/>
+</head>
+
 # Troubleshooting Rancher upgrades
 
 :::warning warning

--- a/versioned_docs/version-1.3/troubleshooting-reset.md
+++ b/versioned_docs/version-1.3/troubleshooting-reset.md
@@ -3,6 +3,10 @@ sidebar_label: Reset
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-reset"/>
+</head>
+
 # Troubleshooting reset
 
 Each `MachineInventory` with the `elemental.cattle.io/resettable: "true"` annotation will trigger the execution of a reset plan, upon deletion.  

--- a/versioned_docs/version-1.3/troubleshooting-restore.md
+++ b/versioned_docs/version-1.3/troubleshooting-restore.md
@@ -3,6 +3,10 @@ sidebar_label: Restore
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-restore"/>
+</head>
+
 # Troubleshooting restore
 
 :::warning warning

--- a/versioned_docs/version-1.3/troubleshooting-upgrade.md
+++ b/versioned_docs/version-1.3/troubleshooting-upgrade.md
@@ -3,6 +3,10 @@ sidebar_label: Upgrade
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/troubleshooting-upgrade"/>
+</head>
+
 # Troubleshooting upgrade
 
 ![Upgrade Flow](images/troubleshooting-upgrade.png)

--- a/versioned_docs/version-1.3/upgrade.md
+++ b/versioned_docs/version-1.3/upgrade.md
@@ -3,6 +3,10 @@ sidebar_label: Upgrade
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
+</head>
+
 import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
 import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
 import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"

--- a/versioned_docs/version-1.3/wifi.md
+++ b/versioned_docs/version-1.3/wifi.md
@@ -3,6 +3,10 @@ sidebar_label: Configure Wi-Fi
 title: ''
 ---
 
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/wifi"/>
+</head>
+
 
 ### How to configure Wi-Fi
 


### PR DESCRIPTION
To align with the global Docs SEO optimization, canonical links have been added to all the pages on all the versions.

This will allow users searching for Elemental content to have the latest version displayed on their search results.

Signed-off-by: Nuno do Carmo nuno.carmo@suse.com