### PR TITLE
Add how-to guide for raspi disk image

### DIFF
--- a/docs/quickstart-cli.md
+++ b/docs/quickstart-cli.md
@@ -95,7 +95,7 @@ kubectl apply -f seedimage.yaml
 </TabItem>
 <TabItem value="seedImagerpi" label="Seed Image for Raspberry Pi" default>
 
-The `SeedImage` resource, which automates the creation of an Elemental bootable image (the *seed image*), does not support Raspberry Pi ISOs yet (Click [here](raspi-disk.md) for a guide to build a raw disk image).
+The `SeedImage` resource, which automates the creation of an Elemental bootable image (the *seed image*), does not support Raspberry Pi ISOs yet (click [here](raspi-disk.md) for a guide to build a raw disk image).
 
 We will generate a *seed image* manually in the [next section](quickstart-cli.md#preparing-the-installation-seed-image).
 

--- a/docs/quickstart-cli.md
+++ b/docs/quickstart-cli.md
@@ -95,7 +95,8 @@ kubectl apply -f seedimage.yaml
 </TabItem>
 <TabItem value="seedImagerpi" label="Seed Image for Raspberry Pi" default>
 
-The `SeedImage` resource, which automates the creation of an Elemental bootable image (the *seed image*), does not support Raspberry Pi yet.
+The `SeedImage` resource, which automates the creation of an Elemental bootable image (the *seed image*), does not support Raspberry Pi ISOs yet (Click [here](raspi-disk.md) for a guide to build a raw disk image).
+
 We will generate a *seed image* manually in the [next section](quickstart-cli.md#preparing-the-installation-seed-image).
 
 Now that we have defined all the configuration files let's apply them to create the proper resources in Kubernetes:

--- a/docs/raspi-disk.md
+++ b/docs/raspi-disk.md
@@ -1,0 +1,53 @@
+---
+sidebar_label: Building raw disk images for Raspberry Pi
+title: ''
+---
+
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/raspi-disk"/>
+</head>
+
+
+### How to build raw disk images for Raspberry Pi
+
+This guide will show how we can build a raw disk image that can be written to an SD-card and booted without any other installation media.
+
+:::caution
+Any data on the SD-card will be erased, please only use a SD-card without anything important on it.
+
+The SD-card must be reasonably large (32 GB or more) and **fast** (!!).
+:::
+
+```yaml title="SeedImage resource" showLineNumbers
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: fire-img
+  namespace: fleet-default
+spec:
+  type: raw
+  baseImage: registry.opensuse.org/isv/rancher/elemental/dev/containers/suse/sle-micro/5.5:latest
+  targetPlatform: linux/arm64
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: fire-nodes
+    namespace: fleet-default
+```
+
+Check the logs for the build pod using:
+
+```shell
+kubectl logs -n fleet-default fire-img -f -c build
+```
+
+When the build is finished we can download the image file using wget:
+
+```shell
+wget --no-check-certificate $(kubectl get seedimage -n fleet-default fire-img -o jsonpath="{.status.downloadURL}") -O sle-micro.arm64.raw
+```
+
+Now we can write the `.raw` image to the SD-card. This can be done with `dd` on the Linux command line if you're comfortable with this command.
+[openSUSE](https://www.opensuse.org) has nice instructions on how to write an image to a storage medium for [Linux](https://en.opensuse.org/SDB:Live_USB_stick),
+[Windows](https://en.opensuse.org/SDB:Create_a_Live_USB_stick_using_Windows), and [OS X](https://en.opensuse.org/SDB:Create_a_Live_USB_stick_using_macOS).
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -88,7 +88,8 @@ const sidebars = {
         'rancher-vmware',
         'removable-device-cloudconfig',
         'custom-certificate',
-        'airgap'
+        'airgap',
+        'raspi-disk'
       ]
     },
     {


### PR DESCRIPTION
The how-to shows how to add a SeedImage that generates a raw disk image fit for writing to an SD-card and use for a Raspberry Pi machine.

Fixes https://github.com/rancher/elemental-docs/issues/243