### PR TITLE
Fix missing image in customizing

### DIFF
--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -316,18 +316,19 @@ Elemental Teal leverages container images to build its root filesystems; therefo
 to use it in a multi-stage environment to create custom bootable media that bundles a custom container image.
 
 ```docker showLineNumbers
-FROM registry.suse.com/rancher/elemental-teal/5.4:latest as os
+FROM registry.suse.com/suse/sle-micro/5.5:latest AS os
 
 # Check the section on remastering a custom docker image
 
-FROM registry.suse.com/rancher/elemental-builder-image/5.4:latest AS builder
+# The released OS already includes the toolchain for building ISOs
+FROM registry.suse.com/suse/sle-micro/5.5:latest AS builder
 
 ARG TARGETARCH
 WORKDIR /iso
 COPY --from=os / rootfs
 
 # work around buildah issue: https://github.com/containers/buildah/issues/4242
-RUN rm rootfs/etc/resolv.conf
+RUN rm -f rootfs/etc/resolv.conf
 
 RUN --mount=type=bind,source=./,target=/output,rw \
       elemental build-iso \

--- a/versioned_docs/version-1.3/customizing.md
+++ b/versioned_docs/version-1.3/customizing.md
@@ -320,14 +320,15 @@ FROM registry.suse.com/rancher/elemental-teal/5.4:latest as os
 
 # Check the section on remastering a custom docker image
 
-FROM registry.suse.com/rancher/elemental-builder-image/5.4:latest AS builder
+# The released OS already includes the toolchain for building ISOs
+FROM registry.suse.com/rancher/elemental-teal/5.4:latest AS builder
 
 ARG TARGETARCH
 WORKDIR /iso
 COPY --from=os / rootfs
 
 # work around buildah issue: https://github.com/containers/buildah/issues/4242
-RUN rm rootfs/etc/resolv.conf
+RUN rm -f rootfs/etc/resolv.conf
 
 RUN --mount=type=bind,source=./,target=/output,rw \
       elemental build-iso \

--- a/versioned_docs/version-1.4/customizing.md
+++ b/versioned_docs/version-1.4/customizing.md
@@ -316,18 +316,19 @@ Elemental Teal leverages container images to build its root filesystems; therefo
 to use it in a multi-stage environment to create custom bootable media that bundles a custom container image.
 
 ```docker showLineNumbers
-FROM registry.suse.com/rancher/elemental-teal/5.4:latest as os
+FROM registry.suse.com/suse/sle-micro/5.5:latest AS os
 
 # Check the section on remastering a custom docker image
 
-FROM registry.suse.com/rancher/elemental-builder-image/5.4:latest AS builder
+# The released OS already includes the toolchain for building ISOs
+FROM registry.suse.com/suse/sle-micro/5.5:latest AS builder
 
 ARG TARGETARCH
 WORKDIR /iso
 COPY --from=os / rootfs
 
 # work around buildah issue: https://github.com/containers/buildah/issues/4242
-RUN rm rootfs/etc/resolv.conf
+RUN rm -f rootfs/etc/resolv.conf
 
 RUN --mount=type=bind,source=./,target=/output,rw \
       elemental build-iso \


### PR DESCRIPTION
In 5.4 we stopped using the builder image to build ISOs in favor
of using the OS container itself as it already includes all the required
tools to build the ISO.

This prevents and additiona image download and ensures the elemental
toolkit is consistent with the one actually included within the
container OS.

Fixes rancher/elemental#1250