### PR TITLE
Remove type field in SeedImage example

### DIFF
--- a/examples/quickstart/seedimage.yaml
+++ b/examples/quickstart/seedimage.yaml
@@ -4,7 +4,6 @@ metadata:
   name: fire-img
   namespace: fleet-default
 spec:
-  type: iso
   baseImage: registry.suse.com/rancher/elemental-teal-iso/5.4:1.2.2
   registrationRef:
     apiVersion: elemental.cattle.io/v1beta1


### PR DESCRIPTION
Since the examples are not versioned with the rest of the quickstart, type field will break when installed on previous versions.

This removes the field, which is set to the default value.