### PR TITLE
Use /elemental-iso artifact path for custom iso images

### DIFF
--- a/docs/custom-images.md
+++ b/docs/custom-images.md
@@ -86,7 +86,7 @@ RUN elemental build-iso \
         -o /output -n "elemental-${TARGETARCH}"
 
 FROM busybox
-COPY --from=builder /output /custom-iso
+COPY --from=builder /output /elemental-iso
 
 ENTRYPOINT ["busybox", "sh", "-c"]
 ```
@@ -105,7 +105,7 @@ this container image can be pushed to an OCI registry too. The ISO image can be
 extracted from the container to the current folder by executing the container as:
 
 ```bash showLineNumbers
-docker run --rm -v $(pwd):/host mytest-image "busybox cp /custom-iso/*.iso /host"
+docker run --rm -v $(pwd):/host mytest-image "busybox cp /elemental-iso/*.iso /host"
 ```
 
 The new customized installation media can be found in `elemental-<arch>.iso`.

--- a/versioned_docs/version-1.5/custom-images.md
+++ b/versioned_docs/version-1.5/custom-images.md
@@ -86,7 +86,7 @@ RUN elemental build-iso \
         -o /output -n "elemental-${TARGETARCH}"
 
 FROM busybox
-COPY --from=builder /output /custom-iso
+COPY --from=builder /output /elemental-iso
 
 ENTRYPOINT ["busybox", "sh", "-c"]
 ```
@@ -105,7 +105,7 @@ this container image can be pushed to an OCI registry too. The ISO image can be
 extracted from the container to the current folder by executing the container as:
 
 ```bash showLineNumbers
-docker run --rm -v $(pwd):/host mytest-image "busybox cp /custom-iso/*.iso /host"
+docker run --rm -v $(pwd):/host mytest-image "busybox cp /elemental-iso/*.iso /host"
 ```
 
 The new customized installation media can be found in `elemental-<arch>.iso`.


### PR DESCRIPTION
As reported by a user on Slack, the `/custom-iso` path is not compatible with the SeedImageBuilder logic, that looks into `/elemental-iso` instead. Build will fail with:

```
cp: can't stat '/elemental-iso/*.iso': No such file or directory
```

Using `/elemental-iso` should fix the problem.