### PR TITLE
Use latest Rancher doc link

### DIFF
--- a/docs/partials/_quickstart-prereqs.md
+++ b/docs/partials/_quickstart-prereqs.md
@@ -1,7 +1,7 @@
 ## Prerequisites
 
 * A Rancher server (v2.7.0 or later) configured (server-url set)
-  * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
+  * To configure the Rancher `server-url` please check the [Rancher docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm#add-tpm-module-to-virtual-machine)
   * Hint 2: You can enable TPM emulation on bare metal machines missing the TPM 2.0 module [example here](tpm#add-tpm-emulation-to-bare-metal-machine)

--- a/versioned_docs/version-1.2/partials/_quickstart-prereqs.md
+++ b/versioned_docs/version-1.2/partials/_quickstart-prereqs.md
@@ -1,7 +1,7 @@
 ## Prerequisites
 
 * A Rancher server (v2.7.0 or later) configured (server-url set)
-  * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
+  * To configure the Rancher `server-url` please check the [Rancher docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm#add-tpm-module-to-virtual-machine)
   * Hint 2: You can enable TPM emulation on bare metal machines missing the TPM 2.0 module [example here](tpm#add-tpm-emulation-to-bare-metal-machine)

--- a/versioned_docs/version-1.3/partials/_quickstart-prereqs.md
+++ b/versioned_docs/version-1.3/partials/_quickstart-prereqs.md
@@ -1,7 +1,7 @@
 ## Prerequisites
 
 * A Rancher server (v2.7.0 or later) configured (server-url set)
-  * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
+  * To configure the Rancher `server-url` please check the [Rancher docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm#add-tpm-module-to-virtual-machine)
   * Hint 2: You can enable TPM emulation on bare metal machines missing the TPM 2.0 module [example here](tpm#add-tpm-emulation-to-bare-metal-machine)

--- a/versioned_docs/version-1.4/partials/_quickstart-prereqs.md
+++ b/versioned_docs/version-1.4/partials/_quickstart-prereqs.md
@@ -1,7 +1,7 @@
 ## Prerequisites
 
 * A Rancher server (v2.7.0 or later) configured (server-url set)
-  * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
+  * To configure the Rancher `server-url` please check the [Rancher docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm#add-tpm-module-to-virtual-machine)
   * Hint 2: You can enable TPM emulation on bare metal machines missing the TPM 2.0 module [example here](tpm#add-tpm-emulation-to-bare-metal-machine)

--- a/versioned_docs/version-1.5/partials/_quickstart-prereqs.md
+++ b/versioned_docs/version-1.5/partials/_quickstart-prereqs.md
@@ -1,7 +1,7 @@
 ## Prerequisites
 
 * A Rancher server (v2.7.0 or later) configured (server-url set)
-  * To configure the Rancher `server-url` please check the [Rancher docs](https://rancher.com/docs/rancher/v2.6/en/admin-settings/#first-log-in)
+  * To configure the Rancher `server-url` please check the [Rancher docs](https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration#first-log-in)
 * A machine (bare metal or virtualized) with TPM 2.0
   * Hint 1: Libvirt allows setting virtual TPMs for virtual machines [example here](tpm#add-tpm-module-to-virtual-machine)
   * Hint 2: You can enable TPM emulation on bare metal machines missing the TPM 2.0 module [example here](tpm#add-tpm-emulation-to-bare-metal-machine)


### PR DESCRIPTION
Closes #347 

@kkaempf I replaced the links to always point to latest version of Rancher docs, however this is not fully predictable as the page might be moved somewhere else in the future. Still I find this simpler to maintain.

An alternative would be to always use versioned docs links, but then I miss the compatibility matrix between elemental-operator and Rancher. I also feel that we will then forget to update the link at each elemental-operator release. :D 

What do you think?