### PR TITLE
label templates: rework section and add "Random" labels

### DIFF
--- a/docs/hardwarelabels.md
+++ b/docs/hardwarelabels.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Hardware Labels
+sidebar_label: Hardware
 title: ''
 ---
 
@@ -17,7 +17,7 @@ This data can be used for easy identification and selection via a [MachineSelect
 
 The following are available for templating:
 
-| Label                                                         | Description                                                           |
+| Variable                                                      | Description                                                           |
 | ------------------------------------------------------------- | --------------------------------------------------------------------- |
 | `${System Data/Runtime/Hostname}`                             | The hostname of the node (at registration time)                       |
 | `${System Data/Memory/Total Physical Bytes}`                  | The total RAM memory in the node, expressed in bytes                  |

--- a/docs/hardwarelabels.md
+++ b/docs/hardwarelabels.md
@@ -9,9 +9,9 @@ title: ''
 
 import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
 
-## Hardware Labels
+## Hardware Template Variables
 
-When a node is registered, hardware data is collected and made available to the MachineRegistration in the same way as [SMBIOS data](smbios.md).
+When a node is registered, hardware data is collected and made available to the MachineRegistration in a way similar to [SMBIOS variables](smbios.md).
 
 This data can be used for easy identification and selection via a [MachineSelector](machineinventoryselectortemplate-reference.md).
 
@@ -66,4 +66,4 @@ On both `Block Devices` and `Network` the device name is used as a sub-block, as
 
 ### Example MachineRegistration
 
-<CodeBlock language="yaml" title="registration example with smbios labels" showLineNumbers>{Registration}</CodeBlock>
+<CodeBlock language="yaml" title="registration example with Hardware template variables" showLineNumbers>{Registration}</CodeBlock>

--- a/docs/label-templates-random.md
+++ b/docs/label-templates-random.md
@@ -1,0 +1,39 @@
+---
+sidebar_label: Random
+title: ''
+---
+
+import Registration from "!!raw-loader!@site/examples/quickstart/registration-random-hostname.yaml"
+
+## Random Template Variables
+
+Random template variables are built-in in the Elemental Operator.
+
+They allow to include random `Int`, `Hex` or `UUID` values in custom [label templates](label-templates).
+
+The values are computed on the fly during the `label template variables` rendering.
+
+| Variable                                 | Description                                                           |
+| ---------------------------------------- | --------------------------------------------------------------------- |
+| `${Random/UUID}`                         | random UUID (e.g., fd95324a-c26b-4e28-8727-1dcec293a0ec)              |
+| `${Random/Hex/[1-32]}`                   | random hexadecimal string of the specified lenght (min 1, max 32)     |
+| `${Random/Int/[MAXINT]`                  | random integer (min 0, max MAXINT-1)                                  |
+
+
+:::note Rendering Examples
+| template value         | rendered value example               |
+|------------------------|--------------------------------------|
+| `${Random/UUID}`      | fd95324a-c26b-4e28-8727-1dcec293a0ec |
+| `${Random/Hex/12}`    | acd231f222b8                         |
+| `${Random/Int/10000}` | 9432                                 |
+:::
+
+The Random Template Variables can be handy for generating custom hostnames to be assigned to the registering host.
+
+Since the hostname must be unique and is assigned through the
+[MachineRegistration](machineregistration-reference) `spec.machineName` field, Random variables can be used
+to ensure uniqueness of a group of host sharing the same custom prefix and/or suffix.
+
+Check the [HowTo/Customize hostname](hostname) section for more information.
+
+<CodeBlock language="yaml" title="registration example Random template variables" showLineNumbers>{Registration}</CodeBlock>

--- a/docs/label-templates.md
+++ b/docs/label-templates.md
@@ -1,0 +1,129 @@
+---
+sidebar_label: Label Templates
+title: ''
+---
+
+<head>
+  <link rel="canonical" href="https://elemental.docs.rancher.com/label-templates"/>
+</head>
+
+# Label Templates Overview
+Elemental allows to specify *label templates* in the `spec.machineInventoryLabels` section of the 
+[MachineRegistration](machineregistration-reference).
+
+Their format is the canonical `key`:`value` used in Kubernetes labels.
+
+These label templates are converted to actual labels attached to each
+[MachineInventory](machineinventory-reference) resources created during the
+[machine onboarding](architecture-machineonboarding) phase.
+
+The resulting labels have the same `key` of the label template.
+
+The associated `value` is generated:
+* **rendering the [`label template variables`](#label-template-variables)** (if present)
+* **`sanitizing`** the resulting value
+
+
+:::info
+The Elemental templating functionality covers also the [MachineRegistration] `spec.machineName` field,
+which defines the resulting hostname of the registering machine and the `name` of the associated
+[MachineInventory](machineinventory-reference) resource.
+
+See the [Machine Name](#machine-name) section for more details.
+:::
+
+## Label Template Variables
+Elemental Label Templating includes a set of predefined variables that could be used inside the `value` of
+the *label templates* specified in the [MachineRegistration](machineregistration-reference).
+
+The syntax used to specify template variables is:
+
+**\$\{ *VARFAMILY* \/ *VARPATH* \}**
+
+where _VARFAMILY_ defines a group (family) of supported variables and _VARPATH_ defines the actual variable
+name inside the belonging family group.
+
+Elemental currently supports three families of template variables:
+* **SMBIOS**:  **\$\{ System Information \/** _VARPATH_ **\}**
+* **HARDWARE**:  **\$\{ System Data \/** _VARPATH_ **\}**
+* **RANDOM**:  **\$\{ Random \/** _VARPATH_ **\}**
+
+Template variables can be mixed with static text to form the actual labels assigned to
+([MachineInventories](machineinventory-reference)).
+
+:::note Rendering Examples
+* Template label tracking the number of CPU cores of the registering host (assume host has 4 cores):
+  * template label: **cpu: $\{System Data\/CPU\/Total Cores\}-cores**
+  * rendered label: **cpu: 4-cores**
+* Template label to track the SMBIOS UUID of the registering host:
+  * template label: **sbios-UUID: \$\{System Information\/UUID\}**
+  * rendered label: **sbios-UUID: fd95324a-c26b-4e28-8727-1dcec293a0ec**
+:::
+
+## Sanitization
+Once the label template value has been rendered accordingly to the included [label template variables](#label-template-variables), the resulting value is `sanitized` before being assigned to the resulting label.
+
+**The `sanitization` enforce the label value to only contain letters (capitalized or not), numbers and the hyphen (`-`), point (`.`) and underscore (`_`) characters**:
+all the characters not included are substituted with an underscore.
+
+If an underscore is at the beginning or at the end of the label value, it is dropped.
+
+Two consecutive underscores are replaced with one.
+
+:::note Rendering Example
+* Template label with not allowed chars sanitization:
+  * template label: **sanitized: this:needs--sanitizing!**
+  * rendered label: **sanitized: this-needs-sanitizing**
+:::
+
+## Usage of template labels
+Template labels allow to automatically attach labels to each host's
+[MachineInventory](machineinventory-reference) every time an host register to the Elemental Operator.
+
+:::info
+Registration happens not only during the [onboarding phase](architecture-machineonboarding): each host
+re-registers every 30 minutes (and every time it reboots).
+During the re-registration, the template labels in the associated
+[MachineRegistration](machineregistration-reference) are re-evaluated and added/updated in the
+[MachineInventory](machineinventory-reference).
+:::
+
+There are basically three main cases where the template labels are handy:
+* as hardware data added to the Elemental catalog
+* as selectors for Cluster Provisioning
+* as template for custom Machine Names
+
+### Hardware data for the Elemental catalog
+The [SMBIOS](smbios) and [Hardware](hardwarelabels) template variables can be used to attach to each
+[MachineInventory](machineinventory-reference) hardware and system data of each host.
+
+### Selectors for Cluster Provisioning
+The `template labels` can be used to indentify and select machines with special properties to form
+a new Kubernetes Cluster.
+
+The labels generated for each [MachineInventory](machineinventory-reference) are an handy selector for the
+[MachineInventorySelectorTemplate](machineinventoryselectortemplate-reference) resource
+(see the [Kubernetes Cluster provisioning](architecture-clusterdeployment#kubernetes-cluster-provisioning)
+section for more details).
+
+### Custom Machine Names
+The hostname of the onboarding machine can be specified using the
+[MachineRegistration](machineregistration-reference) `spec.machineName` field.
+
+`spec.machineName` value undergoes the same `label templates variables` and `sanitization` process reserved
+to the `spec.machineInventoryLabels` label values.
+
+:::warning
+There is one notable difference during the [sanitization](#sanitization) rendering: the underscore (`_`) is
+not allowed and is dealt as the other forbidden characters (i.e., it is substituted by an hyphen: `-`).
+This is required as the underscore is not allowed in the OS hostnames.
+:::
+
+For more information on how to define the hostname for Elemental hosts, see the
+[HowTo/Customize hostname](hostname) section.
+
+:::note Rendering Example
+* Define an hostname template like `SLE-Micro-[random string of 6 hexadecimal values]`:
+  * MachineRegistration spec: **machineName: SLE-Micro-\$\{Random\/Hex\/6\}**
+  * MachineInventory name: **SLE-Micro-32ad41**
+:::

--- a/docs/label-templates.md
+++ b/docs/label-templates.md
@@ -29,7 +29,7 @@ The Elemental templating functionality covers also the [MachineRegistration] `sp
 which defines the resulting hostname of the registering machine and the `name` of the associated
 [MachineInventory](machineinventory-reference) resource.
 
-See the [Machine Name](#machine-name) section for more details.
+See the [Machine Name](#custom-machine-names) section for more details.
 :::
 
 ## Label Template Variables

--- a/docs/smbios.md
+++ b/docs/smbios.md
@@ -1,5 +1,5 @@
 ---
-sidebar_label: Smbios
+sidebar_label: SMBIOS
 title: ''
 ---
 
@@ -9,27 +9,19 @@ title: ''
 
 import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
 
-## Introduction
+## SMBIOS Template Variables
 
 The System Management BIOS (SMBIOS) specification defines data structures (and access methods) that can be used to read management information produced by the BIOS of a computer.
 
 This allows us to gather hardware information about the running system and use that as part of our labels.
 
-## How does Elemental use SMBIOS data?
+The [Elemental Register Client](architecture-components#elemental-register-command-line-tool) gathers SMBIOS data running the `dmidecode` binary during the initial registration of the machine and
+sends that data to the [Elemental Operator](architecture-components#elemental-operator-daemon).
 
-The registration client tries to gather SMBIOS data by running `dmidecode` during the initial registration of the node and that data is
-sent to the registration controller to use on interpolating different fields in the inventory that we create for that node.
+That data is used to render the [template label variables](label-templates#label-template-variables) in the [MachineInventory](machineinventory-reference) associated to that machine.
 
-Currently, we support interpolating that data into the `machineName` and the `machineInventoryLabels` of a [machineRegistration](machineregistration-reference.md)
-
-The interpolation format is as follows:
-
-`{$KEY/VALUE}` and `${KEY/SUBKEY/VALUE}`
-
-This can be mixed with normal strings so `my-prefix-${KEY/VALUE}` would result into the resolved values with `my-prefix-` prefixed
-
-
-For example, having the following SMBIOS data:
+:::note Example
+Having the following SMBIOS data:
 
 ```console showLineNumbers
 System Information
@@ -41,13 +33,6 @@ System Information
 ```
 
 And setting the `machineName` to `serial-${System Information/Serial Number}` would result in the final value of `serial-THX1138`
-
-This is useful to generate automatic names for machines based on their hardware values, for example using the UUID or the Product name.
-Our default `machineName` when the registration values are empty is `"m-${System Information/UUID}"`.
-
-:::warning warning
-All non-valid characters will be changed into `-` automatically on parse. Valid characters for labels are alphanumeric and `-`,`_` and `.`
-For machineName the constraints are stricter as that value is used for the hostname so valid values are lowercase alphanumeric and `-` only.
 :::
 
 A good use of SMBIOS data is to set up different labels for all your machines and get those values from the hardware directly.
@@ -57,4 +42,4 @@ you to use selectors down the line to select similar machines.
 
 For example using the following label `cpuFamily: "${Processor Information/Family}` would allow you to use a selector to search for i7 cpus in your machine fleet.
 
-<CodeBlock language="yaml" title="registration example with smbios labels" showLineNumbers>{Registration}</CodeBlock>
+<CodeBlock language="yaml" title="registration example with SMBIOS template variables" showLineNumbers>{Registration}</CodeBlock>

--- a/examples/quickstart/registration-random-hostname.yaml
+++ b/examples/quickstart/registration-random-hostname.yaml
@@ -1,0 +1,19 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: "fire-node-${Random/Hex/12}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/UUID: "${Random/UUID}"

--- a/sidebars.js
+++ b/sidebars.js
@@ -62,6 +62,18 @@ const sidebars = {
       ]
     },
     "authentication",
+    {
+      "type": "category",
+      "collapsible": true,
+      "collapsed": true,
+      "label": "Label Templates",
+      "link": {"type": "doc", "id": "label-templates"},
+      "items": [
+        "smbios",
+        "hardwarelabels",
+        "label-templates-random",
+      ]
+    },
     "networking",
     {
       "type": "category",


### PR DESCRIPTION
Merge the "SMBIOS" and "Hardware labels" sections and deal with "label templates" more generally in the docs.
Add the section about the new "Random" labels recently added to the operator.

Fixes #359 