### PR TITLE
Document Network config applied in recovery too

### DIFF
--- a/docs/troubleshooting-network.md
+++ b/docs/troubleshooting-network.md
@@ -177,7 +177,6 @@ stages:
                 nm-configurator.interface.description=Main-NIC
               encoding: ""
               ownerstring: ""
-          if: '[ ! -f /run/elemental/recovery_mode ]'
 ```
 
 ### During reset


### PR DESCRIPTION
Network config is now applied in recovery too. See https://github.com/rancher/elemental-operator/pull/822