### PR TITLE
label templates: fix sanitization section

### DIFF
--- a/docs/label-templates.md
+++ b/docs/label-templates.md
@@ -64,11 +64,12 @@ Template variables can be mixed with static text to form the actual labels assig
 Once the label template value has been rendered accordingly to the included [label template variables](#label-template-variables), the resulting value is `sanitized` before being assigned to the resulting label.
 
 **The `sanitization` enforce the label value to only contain letters (capitalized or not), numbers and the hyphen (`-`), point (`.`) and underscore (`_`) characters**:
-all the characters not included are substituted with an underscore.
+all the characters not included are substituted with an hyphen.
 
-If an underscore is at the beginning or at the end of the label value, it is dropped.
+Any character at the beginning and at the end of the label value must be a letter or a number.
+If it is not, it is dropped.
 
-Two consecutive underscores are replaced with one.
+Two consecutive hyphens are replaced with one.
 
 :::note Rendering Example
 * Template label with not allowed chars sanitization:


### PR DESCRIPTION
Invalid chars are substituted with an hyphen, not an underscore.
Moreover, all characters which are not a letter or a number are dropped from the beginning and the end of the rendered labels.

Fixes #365