### PR TITLE
Add  'System Annotations' table

### DIFF
--- a/docs/hostname.md
+++ b/docs/hostname.md
@@ -38,7 +38,8 @@ The hostname can be specified setting the [`machineName`](machineregistration-re
 ['MachineRegistration'](machineregistration-reference.md) resource.
 
 The hostname set in the `machineName` field is expected to be in a template form, in order to be uniquely generated
-for each registering node, using [SMBIOS](smbios.md) and [Hardware Labels](hardwarelabels.md) data.
+for each registering node, using the [Random](label-templates-random.md), [SMBIOS](smbios.md) and [Hardware](hardwarelabels.md)
+variables from the [Label Templates](label-templates.md) feature.
 
 :::caution important note
 The `machineName` field in the `MachineRegistration` resource is used as the blueprint not

--- a/docs/inventory-management.md
+++ b/docs/inventory-management.md
@@ -16,10 +16,30 @@ the mapping of the machine to it's configuration and assigned cluster.
 ### MachineInventory
 
 The `MachineInventory` holds all the relevant information for a registered machine.  
-Upon successful registration, the `MachineInventory` will inherit all `machineInventoryLabels` defined in the related `MachineRegistration`.  
-Additionally, the machine `annotations` will also be updated on each successful registration.  
 
-By default, Elemental machines will attempt a registration update every 24 hours to update labels and annotations.  
+Upon successful registration, the `MachineInventory` inherits all the `machineInventoryLabels`
+and the `machineInventoryAnnotations` defined in the associated `MachineRegistration`.
+
+The registering host sends also a bunch of [`system annotations`](#system-annotations) tracking information regarding the authentication
+method used, the running OS version and the current IP address.
+
+Those annotations are added to the associated [MachineInventory](machineinventory-reference.md).
+
+Elemental machines attempt a registration update every 30 minutes to update labels and annotations.
+
+#### System Annotations
+| Key                                         | Description                                                                                |
+|---------------------------------------------|--------------------------------------------------------------------------------------------|
+| elemental.cattle.io/auth                    | Authentication used during registration (one of 'tpm', 'emulated-tpm', 'mac', 'sys-uuid')  |
+| elemental.cattle.io/registration-ip         | IP address used during last registration                                                   |
+| elemental.cattle.io/os.unmanaged            | Only present when set to 'true', disables OS management functionality on the tracked host  |
+| elemental.cattle.io/name                    | 'NAME' from /etc/os-release                                                                |
+| elemental.cattle.io/version                 | 'VERSION' from /etc/os-release                                                             |
+| elemental.cattle.io/version-id              | 'VERSION_ID' from /etc/os-release                                                          |
+| elemental.cattle.io/id                      | 'ID' from /etc/os-release                                                                  |
+| elemental.cattle.io/pretty-name             | 'PRETTY_NAME' from /etc/os-release                                                         |
+| elemental.cattle.io/image                   | 'IMAGE' from /etc/os-release                                                               |
+| elemental.cattle.io/cpe-name                | 'CPE_NAME' from /etc/os-release                                                            |
 
 #### Reference
 
@@ -65,11 +85,15 @@ spec:
 
 `MachineRegistration` holds information on how to install, reset, and configure all connected Elemental machines.  
 
-It's possible to update the `spec.machineInventoryLabels` and `spec.machineInventoryAnnotations` and this will be applied to all registered machines.
-By default, Elemental machines will attempt a registration update every 24 hours to update labels and annotations.
+The `spec.machineInventoryLabels` and `spec.machineInventoryAnnotations` fields hold label and annotation templates
+rendered to actual labels and annotations applied to the [MachineInventories](machineinventory-reference.md) tracking
+the registered machines.
+
+Elemental machines attempt a registration update every 30 minutes to update labels and annotations.
 
 While it's possible to modify the `spec.config` definition, updates to the `spec.config` will be ignored by machines that already completed installation.
-Machines that couldn't complete the installation will try again every 30 minutes by reloading the remote `MachineRegistration` definition. This can be useful to correct `spec.config` mistakes that prevent successful installation (for ex. `spec.config.elemental.install.device`), without having to create a new `MachineRegistration` and a new ISO.  
+Machines that couldn't complete the installation will try again every 30 minutes by reloading the remote `MachineRegistration` definition.
+This can be useful to correct `spec.config` mistakes that prevent successful installation (for ex. `spec.config.elemental.install.device`), without having to create a new `MachineRegistration` and a new ISO.
 
 #### Reference
 

--- a/docs/label-templates.md
+++ b/docs/label-templates.md
@@ -45,8 +45,18 @@ name inside the belonging family group.
 
 Elemental currently supports three families of template variables:
 * **SMBIOS**:  **\$\{ System Information \/** _VARPATH_ **\}**
-* **HARDWARE**:  **\$\{ System Data \/** _VARPATH_ **\}**
-* **RANDOM**:  **\$\{ Random \/** _VARPATH_ **\}**
+* **Hardware**:  **\$\{ System Data \/** _VARPATH_ **\}**
+* **Random**:  **\$\{ Random \/** _VARPATH_ **\}**
+
+:::warning
+**SMBIOS** and **Hardware** variables are enabled only if [MachineRegistration](machineregistration-reference.md)
+`elemental:registration:no-smbios` field is set to `false` (default).
+
+When `elemental:registration:no-smbios` field is set to `true`, the registering machines do not send any
+SMBIOS and hardware data and the **SMBIOS** and **Hardware** data will not be available.
+
+**Random** variables are always available instead.
+:::
 
 Template variables can be mixed with static text to form the actual labels assigned to
 ([MachineInventories](machineinventory-reference)).

--- a/docs/machineregistration-reference.md
+++ b/docs/machineregistration-reference.md
@@ -226,14 +226,14 @@ Supports the following values:
 
 #### machineName
 
-This refers to the name that will be set to the node and the kubernetes resources that require a hostname (rke2 deployed pods for example, they use the node hostname as part of the pod names)
-`String` type.
+Template used to derive the hostname to be set to the node and as the name of the associated [MachineInventory](machineinventory-reference.md) kubernetes resource.
+
+The value is interpolated using [Label Templates](label-templates.md).
 
 :::info
-When `elemental:registration:no-smbios` is set to `false` (default), machineName is interpolated with [SMBIOS](https://www.dmtf.org/standards/smbios) data which allows you to store hardware information.
-See our [SMBIOS docs](smbios.md) for more information.
 If no `machineName` is specified, a default one in the form `m-$UUID` will be set.
-The UUID will be retrieved from the SMBIOS data if available, otherwise a random UUID will be generated.
+
+See the [Customize Hostname section](hostname.md#customize-hostname) for further details.
 :::
 
 <details>
@@ -253,16 +253,15 @@ The UUID will be retrieved from the SMBIOS data if available, otherwise a random
 
 #### machineInventoryLabels
 
-Labels that will be set to the `MachineInventory` that is created from this `MachineRegistration`
-`Key: value` type. These labels will be used to establish a selection criteria in [MachineInventorySelectorTemplate](machineinventoryselectortemplate-reference.md).  
+Labels to be set to the `MachineInventory` created from this `MachineRegistration`.
 
-Elemental nodes will run `elemental-register` every 24 hours.  
-It is possible to update the `machineInventoryLabels` so that all registered nodes will apply the new labels on the next successfull registration update.  
+The label values are interpolated using [Label Templates](label-templates.md).
 
-:::info
-When `elemental:registration:no-smbios` is set to `false` (default), Labels are interpolated with [SMBIOS](https://www.dmtf.org/standards/smbios) data. This allows to store hardware information in custom labels.
-See our [SMBIOS docs](smbios.md) for more information.
-:::
+These labels could be used to establish a selection criteria in [MachineInventorySelectorTemplate](machineinventoryselectortemplate-reference.md).
+
+Elemental nodes will run `elemental-register` every 30 minutes.
+
+It is possible to update the `machineInventoryLabels` so that all registered nodes apply the new labels on the next successfull registration update.
 
 <details>
 <summary>Example</summary>

--- a/sidebars.js
+++ b/sidebars.js
@@ -102,8 +102,6 @@ const sidebars = {
         "cluster-reference",
         "elementaloperatorchart-reference",
         "kubernetesversions",
-        "smbios",
-        "hardwarelabels",
       ]
     },
     {


### PR DESCRIPTION
Add documentation about the annotations sent by the registering host tracking live system data (OS, IP, etc.).
Used the arbitrary "System Annotations" name in order to be able to refer them in the docs when needed.

In the meanwhile, fixed and reworked related documentation.

Fixes #360 