### PR TITLE
Update registration example codeblock

### DIFF
--- a/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-nodes
   namespace: fleet-default
 spec:
-  machineName: "${Runtime/Hostname}"
+  machineName: "${System Data/Runtime/Hostname}"
   config:
     cloud-config:
       users:


### PR DESCRIPTION
The example code block in this document https://elemental.docs.rancher.com/hostname/#keep-the-hostname-assigned-from-dhcp does not match the information in the paragraph above it.

> In order to keep the hostname assigned from the DHCP server before the host registers to the operator, the MachineRegistration [machineName field](https://elemental.docs.rancher.com/machineregistration-reference#machinename) should be set to the ${System Data/Runtime/Hostname} [Hardware Label](https://elemental.docs.rancher.com/hardwarelabels).

Code Block Example has:
`machineName: "${Runtime/Hostname}"` needs to be `machineName: "${System Data/Runtime/Hostname}"`

PR fixes https://github.com/rancher/elemental-docs/issues/416