### PR TITLE
Version examples directory to fix yaml examples

### DIFF
--- a/docs/label-templates.md
+++ b/docs/label-templates.md
@@ -86,7 +86,7 @@ Template variables can be mixed with static text to form the actual labels assig
 ## Sanitization
 Once the label template value has been rendered accordingly to the included [label template variables](#label-template-variables), the resulting value is `sanitized` before being assigned to the resulting label.
 
-**The `sanitization` enforce the label value to only contain letters (capitalized or not), numbers and the hyphen (`-`), point (`.`) and underscore (`_`) characters**:
+**The `sanitization` enforces the label value to only contain letters (capitalized or not), numbers and the hyphen (`-`), point (`.`) and underscore (`_`) characters**:
 all the characters not included are substituted with an hyphen.
 
 Any character at the beginning and at the end of the label value must be a letter or a number.

--- a/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-nodes
   namespace: fleet-default
 spec:
-  machineName: "${System Data/Runtime/Hostname}"
+  machineName: "${Runtime/Hostname}"
   config:
     cloud-config:
       users:

--- a/versioned_docs/version-1.2/cluster-reference.md
+++ b/versioned_docs/version-1.2/cluster-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
 </head>
 
-import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
+import Machinepools from "!!raw-loader!./examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference
 

--- a/versioned_docs/version-1.2/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.2/elemental_behind_proxy.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
 </head>
 
-import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
-import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
-import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"
+import RegistrationProxy from "!!raw-loader!./examples/proxy/registration-proxy.yaml"
+import SeedimageProxy from "!!raw-loader!./examples/proxy/seedimage-proxy.yaml"
+import ClusterProxy from "!!raw-loader!./examples/proxy/cluster-proxy.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.2/examples/authentication/registration-emulate-tpm.yaml
+++ b/versioned_docs/version-1.2/examples/authentication/registration-emulate-tpm.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+        emulated-tpm-seed: -1
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.2/examples/authentication/registration-mac.yaml
+++ b/versioned_docs/version-1.2/examples/authentication/registration-mac.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: mac
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.2/examples/authentication/registration-sys-uuid.yaml
+++ b/versioned_docs/version-1.2/examples/authentication/registration-sys-uuid.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: sys-uuid
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.2/examples/clusters/clusters-several-machinepools.yml
+++ b/versioned_docs/version-1.2/examples/clusters/clusters-several-machinepools.yml
@@ -1,0 +1,53 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: cluster-machinepools
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machinePools:
+      - name: controlPlanePool
+        controlPlaneRole: true
+        etcdRole: true
+        workerRole: false
+        quantity: 3
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorControlPlanes
+      - name: workersPool
+        controlPlaneRole: false
+        etcdRole: false
+        workerRole: true
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorWorkers
+  kubernetesVersion: v1.23.7+k3s1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorControlPlanes
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorWorkers
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-2

--- a/versioned_docs/version-1.2/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
+++ b/versioned_docs/version-1.2/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: test-machine
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: password
+      # add your custom cloud-config snippets to customize your system
+      write_files:
+        - content: V2h5IGFyZSB5b3UgY2hlY2tpbmcgdGhpcz8K
+          encoding: b64
+          path: /etc/custom.file
+    elemental:
+      install:
+        reboot: true
+        device: /dev/vda
+        iso: https://something.example.com
+  machineInventoryLabels:
+    clusterName: test

--- a/versioned_docs/version-1.2/examples/network/machineregistration-nmc.yaml
+++ b/versioned_docs/version-1.2/examples/network/machineregistration-nmc.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.2/examples/network/machineregistration-nmconnections.yaml
+++ b/versioned_docs/version-1.2/examples/network/machineregistration-nmconnections.yaml
@@ -1,0 +1,65 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: test-${System Information/UUID}
+  config:
+    network:
+      configurator: "nmconnections"
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        enp1s0: |
+          [connection]
+          id=Wired connection 1
+          type=ethernet
+          interface-name=enp1s0
+          [ipv4]
+          address1={inventory-ip}/24,192.168.1.1
+          dns=192.168.122.1;
+          method=manual
+          route1=0.0.0.0/0,192.168.122.1
+          [ipv6]
+          method=disabled
+        enp8s0: |
+          [connection]
+          id=Wired connection 2
+          type=ethernet
+          interface-name=enp8s0
+          [ipv4]
+          address1={secondary-ip}/24,172.16.0.1
+          method=manual
+          route1=172.16.0.0/24,172.16.0.1,150
+          [ipv6]
+          method=disabled

--- a/versioned_docs/version-1.2/examples/network/machineregistration-nmstate.yaml
+++ b/versioned_docs/version-1.2/examples/network/machineregistration-nmstate.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmstate
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.2/examples/network/machineregistration.yaml
+++ b/versioned_docs/version-1.2/examples/network/machineregistration.yaml
@@ -1,0 +1,52 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.2/examples/network/yip-nmc-static-config.yaml
+++ b/versioned_docs/version-1.2/examples/network/yip-nmc-static-config.yaml
@@ -1,0 +1,78 @@
+name: Static nm-configurator config
+stages:
+  initramfs:
+  - directories:
+      - path: /tmp/nmc/static/desired-states
+        permissions: 448
+        owner: 0
+        group: 0
+      - path: /tmp/nmc/static/network-config
+        permissions: 448
+        owner: 0
+        group: 0
+    files:
+      - path: /tmp/nmc/static/desired-states/node1.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:45:14:c5
+            ipv4:
+              address:
+              - ip: 192.168.122.150
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+      - path: /tmp/nmc/static/desired-states/node2.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:3a:ae:3b
+            ipv4:
+              address:
+              - ip: 192.168.122.151
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+    commands:
+    - nmc generate --config-dir /tmp/nmc/static/desired-states --output-dir /tmp/nmc/static/network-config
+    - nmc apply --config-dir /tmp/nmc/static/network-config

--- a/versioned_docs/version-1.2/examples/proxy/cluster-proxy.yaml
+++ b/versioned_docs/version-1.2/examples/proxy/cluster-proxy.yaml
@@ -1,0 +1,33 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: my-cluster
+  namespace: fleet-default
+spec:
+  agentEnvVars:
+  - name: HTTP_PROXY
+    value: http://<MY_PROXY>:<MY_PORT>
+  - name: HTTPS_PROXY
+    value: https://<MY_PROXY>:<MY_PORT>
+  - name: NO_PROXY
+    value: localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: my-machine-selector
+        name: pool1
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.2/examples/proxy/registration-proxy.yaml
+++ b/versioned_docs/version-1.2/examples/proxy/registration-proxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      write_files:
+      - path: /etc/sysconfig/proxy
+        append: true
+        content: |
+          PROXY_ENABLED="yes"
+          HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+          HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+          NO_PROXY="localhost, 127.0.0.1"
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true

--- a/versioned_docs/version-1.2/examples/proxy/seedimage-proxy.yaml
+++ b/versioned_docs/version-1.2/examples/proxy/seedimage-proxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: ...
+  namespace: ...
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  cloud-config:
+    write_files:
+    - path: /etc/sysconfig/proxy
+      append: true
+      content: |
+        PROXY_ENABLED="yes"
+        HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+        HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+        NO_PROXY="localhost, 127.0.0.1"
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: ...
+    namespace: ...

--- a/versioned_docs/version-1.2/examples/quickstart/cluster.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/cluster.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: volcano
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: fire-machine-selector
+        name: fire-pool
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.2/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  machineName: "${System Data/Runtime/Hostname}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.2/examples/quickstart/registration-hardware.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/registration-hardware.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.2/examples/quickstart/registration-random-hostname.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/registration-random-hostname.yaml
@@ -1,0 +1,19 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: "fire-node-${Random/Hex/12}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/UUID: "${Random/UUID}"

--- a/versioned_docs/version-1.2/examples/quickstart/registration-tpm.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/registration-tpm.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.2/examples/quickstart/registration.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/registration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.2/examples/quickstart/rpi-registration.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/rpi-registration.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/mmcblk0
+        debug: true
+        disable-boot-entry: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.2/examples/quickstart/seedimage.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/seedimage.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: fire-img
+  namespace: fleet-default
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: fire-nodes
+    namespace: fleet-default

--- a/versioned_docs/version-1.2/examples/quickstart/selector.yaml
+++ b/versioned_docs/version-1.2/examples/quickstart/selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: fire-machine-selector
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchExpressions:
+          - key: element
+            operator: In
+            values: [ 'fire' ]

--- a/versioned_docs/version-1.2/examples/upgrade/managed-os-version-channel-custom.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/managed-os-version-channel-custom.yaml
@@ -1,0 +1,9 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-channel
+  namespace: fleet-default
+spec:
+  options:
+    image: registry.suse.com/rancher/elemental-channel:latest
+  type: custom

--- a/versioned_docs/version-1.2/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/managed-os-version-channel-json.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-versions
+  namespace: fleet-default
+spec:
+  options:
+    URI: "https://raw.githubusercontent.com/rancher/elemental-docs/main/examples/upgrade/versions.json"
+    Timeout: "1m"
+  type: json

--- a/versioned_docs/version-1.2/examples/upgrade/upgrade-cluster-target.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/upgrade-cluster-target.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to or track the latest tag
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.2/examples/upgrade/upgrade-force.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/upgrade-force.yaml
@@ -1,0 +1,14 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      - name: FORCE
+        value: "true"

--- a/versioned_docs/version-1.2/examples/upgrade/upgrade-managedos-version.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/upgrade-managedos-version.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name:  my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new ManagedOSVersion you would like to upgrade to
+  managedOSVersionName: v0.1.0-alpha22-amd64
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.2/examples/upgrade/upgrade-node-selector.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/upgrade-node-selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: my-machine

--- a/versioned_docs/version-1.2/examples/upgrade/upgrade-recovery.yaml
+++ b/versioned_docs/version-1.2/examples/upgrade/upgrade-recovery.yaml
@@ -1,0 +1,18 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade-recovery
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      # Use UPGRADE_RECOVERY_ONLY to upgrade the recovery partition only. (This has the same effect as FORCE="true")
+      - name: UPGRADE_RECOVERY_ONLY
+        value: "false"
+      # Use UPGRADE_RECOVERY to upgrade both system and recovery partitions.
+      - name: UPGRADE_RECOVERY
+        value: "true"

--- a/versioned_docs/version-1.2/examples/upgrade/versions.json
+++ b/versioned_docs/version-1.2/examples/upgrade/versions.json
@@ -1,0 +1,28 @@
+[
+  {
+      "metadata": {
+          "name": "my-flavor-v0.1.0"
+      },
+      "spec": {
+          "version": "v0.1.0",
+          "type": "container",
+          "metadata": {
+              "upgradeImage": "foo/bar-os:v0.1.0-myflavor",
+              "displayName": "Foo Bar OS - My Flavor"
+          }
+      }
+  },
+  {
+    "metadata": {
+        "name": "my-flavor-v0.1.0-iso"
+    },
+    "spec": {
+        "version": "v0.1.0",
+        "type": "iso",
+        "metadata": {
+            "uri": "foo/bar-iso:v0.1.0-myflavor",
+            "displayName": "Foo Bar ISO - My Flavor"
+        }
+    }
+  }
+]

--- a/versioned_docs/version-1.2/hardwarelabels.md
+++ b/versioned_docs/version-1.2/hardwarelabels.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware.yaml"
 
 ## Hardware Labels
 

--- a/versioned_docs/version-1.2/managedosimage-reference.md
+++ b/versioned_docs/version-1.2/managedosimage-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/managedosimage-reference"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
 
 # ManagedOSImage reference
 

--- a/versioned_docs/version-1.2/quickstart-cli.md
+++ b/versioned_docs/version-1.2/quickstart-cli.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # Elemental the command line way
 

--- a/versioned_docs/version-1.2/quickstart-ui.md
+++ b/versioned_docs/version-1.2/quickstart-ui.md
@@ -7,10 +7,10 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
 

--- a/versioned_docs/version-1.2/smbios.md
+++ b/versioned_docs/version-1.2/smbios.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.2/tpm.md
+++ b/versioned_docs/version-1.2/tpm.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
 </head>
 
-import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+import RegistrationTpm from "!!raw-loader!./examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)
 

--- a/versioned_docs/version-1.2/upgrade.md
+++ b/versioned_docs/version-1.2/upgrade.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
-import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
-import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"
-import ManagedOSVersion from "!!raw-loader!@site/examples/upgrade/upgrade-managedos-version.yaml"
-import MangedOSVersionChannelJson from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-json.yaml"
-import ManagedOSVersionChannelCustom from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-custom.yaml"
-import Versions from "../examples/upgrade/versions.raw!=!raw-loader!@site/examples/upgrade/versions.json"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
+import NodeSelector from "!!raw-loader!./examples/upgrade/upgrade-node-selector.yaml"
+import UpgradeForce from "!!raw-loader!./examples/upgrade/upgrade-force.yaml"
+import ManagedOSVersion from "!!raw-loader!./examples/upgrade/upgrade-managedos-version.yaml"
+import MangedOSVersionChannelJson from "!!raw-loader!./examples/upgrade/managed-os-version-channel-json.yaml"
+import ManagedOSVersionChannelCustom from "!!raw-loader!./examples/upgrade/managed-os-version-channel-custom.yaml"
+import Versions from "../examples/upgrade/versions.raw!=!raw-loader!./examples/upgrade/versions.json"
 
 # Upgrade
 

--- a/versioned_docs/version-1.3/cluster-reference.md
+++ b/versioned_docs/version-1.3/cluster-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
 </head>
 
-import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
+import Machinepools from "!!raw-loader!./examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference
 

--- a/versioned_docs/version-1.3/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.3/elemental_behind_proxy.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
 </head>
 
-import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
-import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
-import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"
+import RegistrationProxy from "!!raw-loader!./examples/proxy/registration-proxy.yaml"
+import SeedimageProxy from "!!raw-loader!./examples/proxy/seedimage-proxy.yaml"
+import ClusterProxy from "!!raw-loader!./examples/proxy/cluster-proxy.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.3/examples/authentication/registration-emulate-tpm.yaml
+++ b/versioned_docs/version-1.3/examples/authentication/registration-emulate-tpm.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+        emulated-tpm-seed: -1
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.3/examples/authentication/registration-mac.yaml
+++ b/versioned_docs/version-1.3/examples/authentication/registration-mac.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: mac
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.3/examples/authentication/registration-sys-uuid.yaml
+++ b/versioned_docs/version-1.3/examples/authentication/registration-sys-uuid.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: sys-uuid
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.3/examples/clusters/clusters-several-machinepools.yml
+++ b/versioned_docs/version-1.3/examples/clusters/clusters-several-machinepools.yml
@@ -1,0 +1,53 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: cluster-machinepools
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machinePools:
+      - name: controlPlanePool
+        controlPlaneRole: true
+        etcdRole: true
+        workerRole: false
+        quantity: 3
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorControlPlanes
+      - name: workersPool
+        controlPlaneRole: false
+        etcdRole: false
+        workerRole: true
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorWorkers
+  kubernetesVersion: v1.23.7+k3s1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorControlPlanes
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorWorkers
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-2

--- a/versioned_docs/version-1.3/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
+++ b/versioned_docs/version-1.3/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: test-machine
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: password
+      # add your custom cloud-config snippets to customize your system
+      write_files:
+        - content: V2h5IGFyZSB5b3UgY2hlY2tpbmcgdGhpcz8K
+          encoding: b64
+          path: /etc/custom.file
+    elemental:
+      install:
+        reboot: true
+        device: /dev/vda
+        iso: https://something.example.com
+  machineInventoryLabels:
+    clusterName: test

--- a/versioned_docs/version-1.3/examples/network/machineregistration-nmc.yaml
+++ b/versioned_docs/version-1.3/examples/network/machineregistration-nmc.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.3/examples/network/machineregistration-nmconnections.yaml
+++ b/versioned_docs/version-1.3/examples/network/machineregistration-nmconnections.yaml
@@ -1,0 +1,65 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: test-${System Information/UUID}
+  config:
+    network:
+      configurator: "nmconnections"
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        enp1s0: |
+          [connection]
+          id=Wired connection 1
+          type=ethernet
+          interface-name=enp1s0
+          [ipv4]
+          address1={inventory-ip}/24,192.168.1.1
+          dns=192.168.122.1;
+          method=manual
+          route1=0.0.0.0/0,192.168.122.1
+          [ipv6]
+          method=disabled
+        enp8s0: |
+          [connection]
+          id=Wired connection 2
+          type=ethernet
+          interface-name=enp8s0
+          [ipv4]
+          address1={secondary-ip}/24,172.16.0.1
+          method=manual
+          route1=172.16.0.0/24,172.16.0.1,150
+          [ipv6]
+          method=disabled

--- a/versioned_docs/version-1.3/examples/network/machineregistration-nmstate.yaml
+++ b/versioned_docs/version-1.3/examples/network/machineregistration-nmstate.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmstate
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.3/examples/network/machineregistration.yaml
+++ b/versioned_docs/version-1.3/examples/network/machineregistration.yaml
@@ -1,0 +1,52 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.3/examples/network/yip-nmc-static-config.yaml
+++ b/versioned_docs/version-1.3/examples/network/yip-nmc-static-config.yaml
@@ -1,0 +1,78 @@
+name: Static nm-configurator config
+stages:
+  initramfs:
+  - directories:
+      - path: /tmp/nmc/static/desired-states
+        permissions: 448
+        owner: 0
+        group: 0
+      - path: /tmp/nmc/static/network-config
+        permissions: 448
+        owner: 0
+        group: 0
+    files:
+      - path: /tmp/nmc/static/desired-states/node1.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:45:14:c5
+            ipv4:
+              address:
+              - ip: 192.168.122.150
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+      - path: /tmp/nmc/static/desired-states/node2.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:3a:ae:3b
+            ipv4:
+              address:
+              - ip: 192.168.122.151
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+    commands:
+    - nmc generate --config-dir /tmp/nmc/static/desired-states --output-dir /tmp/nmc/static/network-config
+    - nmc apply --config-dir /tmp/nmc/static/network-config

--- a/versioned_docs/version-1.3/examples/proxy/cluster-proxy.yaml
+++ b/versioned_docs/version-1.3/examples/proxy/cluster-proxy.yaml
@@ -1,0 +1,33 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: my-cluster
+  namespace: fleet-default
+spec:
+  agentEnvVars:
+  - name: HTTP_PROXY
+    value: http://<MY_PROXY>:<MY_PORT>
+  - name: HTTPS_PROXY
+    value: https://<MY_PROXY>:<MY_PORT>
+  - name: NO_PROXY
+    value: localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: my-machine-selector
+        name: pool1
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.3/examples/proxy/registration-proxy.yaml
+++ b/versioned_docs/version-1.3/examples/proxy/registration-proxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      write_files:
+      - path: /etc/sysconfig/proxy
+        append: true
+        content: |
+          PROXY_ENABLED="yes"
+          HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+          HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+          NO_PROXY="localhost, 127.0.0.1"
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true

--- a/versioned_docs/version-1.3/examples/proxy/seedimage-proxy.yaml
+++ b/versioned_docs/version-1.3/examples/proxy/seedimage-proxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: ...
+  namespace: ...
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  cloud-config:
+    write_files:
+    - path: /etc/sysconfig/proxy
+      append: true
+      content: |
+        PROXY_ENABLED="yes"
+        HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+        HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+        NO_PROXY="localhost, 127.0.0.1"
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: ...
+    namespace: ...

--- a/versioned_docs/version-1.3/examples/quickstart/cluster.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/cluster.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: volcano
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: fire-machine-selector
+        name: fire-pool
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.3/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  machineName: "${System Data/Runtime/Hostname}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.3/examples/quickstart/registration-hardware.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/registration-hardware.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.3/examples/quickstart/registration-random-hostname.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/registration-random-hostname.yaml
@@ -1,0 +1,19 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: "fire-node-${Random/Hex/12}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/UUID: "${Random/UUID}"

--- a/versioned_docs/version-1.3/examples/quickstart/registration-tpm.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/registration-tpm.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.3/examples/quickstart/registration.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/registration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.3/examples/quickstart/rpi-registration.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/rpi-registration.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/mmcblk0
+        debug: true
+        disable-boot-entry: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.3/examples/quickstart/seedimage.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/seedimage.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: fire-img
+  namespace: fleet-default
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: fire-nodes
+    namespace: fleet-default

--- a/versioned_docs/version-1.3/examples/quickstart/selector.yaml
+++ b/versioned_docs/version-1.3/examples/quickstart/selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: fire-machine-selector
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchExpressions:
+          - key: element
+            operator: In
+            values: [ 'fire' ]

--- a/versioned_docs/version-1.3/examples/upgrade/managed-os-version-channel-custom.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/managed-os-version-channel-custom.yaml
@@ -1,0 +1,9 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-channel
+  namespace: fleet-default
+spec:
+  options:
+    image: registry.suse.com/rancher/elemental-channel:latest
+  type: custom

--- a/versioned_docs/version-1.3/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/managed-os-version-channel-json.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-versions
+  namespace: fleet-default
+spec:
+  options:
+    URI: "https://raw.githubusercontent.com/rancher/elemental-docs/main/examples/upgrade/versions.json"
+    Timeout: "1m"
+  type: json

--- a/versioned_docs/version-1.3/examples/upgrade/upgrade-cluster-target.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/upgrade-cluster-target.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to or track the latest tag
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.3/examples/upgrade/upgrade-force.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/upgrade-force.yaml
@@ -1,0 +1,14 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      - name: FORCE
+        value: "true"

--- a/versioned_docs/version-1.3/examples/upgrade/upgrade-managedos-version.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/upgrade-managedos-version.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name:  my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new ManagedOSVersion you would like to upgrade to
+  managedOSVersionName: v0.1.0-alpha22-amd64
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.3/examples/upgrade/upgrade-node-selector.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/upgrade-node-selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: my-machine

--- a/versioned_docs/version-1.3/examples/upgrade/upgrade-recovery.yaml
+++ b/versioned_docs/version-1.3/examples/upgrade/upgrade-recovery.yaml
@@ -1,0 +1,18 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade-recovery
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      # Use UPGRADE_RECOVERY_ONLY to upgrade the recovery partition only. (This has the same effect as FORCE="true")
+      - name: UPGRADE_RECOVERY_ONLY
+        value: "false"
+      # Use UPGRADE_RECOVERY to upgrade both system and recovery partitions.
+      - name: UPGRADE_RECOVERY
+        value: "true"

--- a/versioned_docs/version-1.3/examples/upgrade/versions.json
+++ b/versioned_docs/version-1.3/examples/upgrade/versions.json
@@ -1,0 +1,28 @@
+[
+  {
+      "metadata": {
+          "name": "my-flavor-v0.1.0"
+      },
+      "spec": {
+          "version": "v0.1.0",
+          "type": "container",
+          "metadata": {
+              "upgradeImage": "foo/bar-os:v0.1.0-myflavor",
+              "displayName": "Foo Bar OS - My Flavor"
+          }
+      }
+  },
+  {
+    "metadata": {
+        "name": "my-flavor-v0.1.0-iso"
+    },
+    "spec": {
+        "version": "v0.1.0",
+        "type": "iso",
+        "metadata": {
+            "uri": "foo/bar-iso:v0.1.0-myflavor",
+            "displayName": "Foo Bar ISO - My Flavor"
+        }
+    }
+  }
+]

--- a/versioned_docs/version-1.3/hardwarelabels.md
+++ b/versioned_docs/version-1.3/hardwarelabels.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware.yaml"
 
 ## Hardware Labels
 

--- a/versioned_docs/version-1.3/managedosimage-reference.md
+++ b/versioned_docs/version-1.3/managedosimage-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/managedosimage-reference"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
 
 # ManagedOSImage reference
 

--- a/versioned_docs/version-1.3/quickstart-cli.md
+++ b/versioned_docs/version-1.3/quickstart-cli.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # Elemental the command line way
 

--- a/versioned_docs/version-1.3/quickstart-ui.md
+++ b/versioned_docs/version-1.3/quickstart-ui.md
@@ -7,10 +7,10 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
 

--- a/versioned_docs/version-1.3/smbios.md
+++ b/versioned_docs/version-1.3/smbios.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.3/tpm.md
+++ b/versioned_docs/version-1.3/tpm.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
 </head>
 
-import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+import RegistrationTpm from "!!raw-loader!./examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)
 

--- a/versioned_docs/version-1.3/upgrade.md
+++ b/versioned_docs/version-1.3/upgrade.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
-import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
-import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"
-import ManagedOSVersion from "!!raw-loader!@site/examples/upgrade/upgrade-managedos-version.yaml"
-import MangedOSVersionChannelJson from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-json.yaml"
-import ManagedOSVersionChannelCustom from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-custom.yaml"
-import Versions from "../examples/upgrade/versions.raw!=!raw-loader!@site/examples/upgrade/versions.json"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
+import NodeSelector from "!!raw-loader!./examples/upgrade/upgrade-node-selector.yaml"
+import UpgradeForce from "!!raw-loader!./examples/upgrade/upgrade-force.yaml"
+import ManagedOSVersion from "!!raw-loader!./examples/upgrade/upgrade-managedos-version.yaml"
+import MangedOSVersionChannelJson from "!!raw-loader!./examples/upgrade/managed-os-version-channel-json.yaml"
+import ManagedOSVersionChannelCustom from "!!raw-loader!./examples/upgrade/managed-os-version-channel-custom.yaml"
+import Versions from "../examples/upgrade/versions.raw!=!raw-loader!./examples/upgrade/versions.json"
 
 # Upgrade
 

--- a/versioned_docs/version-1.4/authentication.md
+++ b/versioned_docs/version-1.4/authentication.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/authentication"/>
 </head>
 
-import RegistrationEmulateTpm from "!!raw-loader!@site/examples/authentication/registration-emulate-tpm.yaml"
-import RegistrationMac from "!!raw-loader!@site/examples/authentication/registration-mac.yaml"
-import RegistrationSysUUID from "!!raw-loader!@site/examples/authentication/registration-sys-uuid.yaml"
+import RegistrationEmulateTpm from "!!raw-loader!./examples/authentication/registration-emulate-tpm.yaml"
+import RegistrationMac from "!!raw-loader!./examples/authentication/registration-mac.yaml"
+import RegistrationSysUUID from "!!raw-loader!./examples/authentication/registration-sys-uuid.yaml"
 
 # Authentication
 

--- a/versioned_docs/version-1.4/cluster-reference.md
+++ b/versioned_docs/version-1.4/cluster-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
 </head>
 
-import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
+import Machinepools from "!!raw-loader!./examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference
 

--- a/versioned_docs/version-1.4/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.4/elemental_behind_proxy.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
 </head>
 
-import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
-import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
-import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"
+import RegistrationProxy from "!!raw-loader!./examples/proxy/registration-proxy.yaml"
+import SeedimageProxy from "!!raw-loader!./examples/proxy/seedimage-proxy.yaml"
+import ClusterProxy from "!!raw-loader!./examples/proxy/cluster-proxy.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.4/examples/authentication/registration-emulate-tpm.yaml
+++ b/versioned_docs/version-1.4/examples/authentication/registration-emulate-tpm.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+        emulated-tpm-seed: -1
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.4/examples/authentication/registration-mac.yaml
+++ b/versioned_docs/version-1.4/examples/authentication/registration-mac.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: mac
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.4/examples/authentication/registration-sys-uuid.yaml
+++ b/versioned_docs/version-1.4/examples/authentication/registration-sys-uuid.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: sys-uuid
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.4/examples/clusters/clusters-several-machinepools.yml
+++ b/versioned_docs/version-1.4/examples/clusters/clusters-several-machinepools.yml
@@ -1,0 +1,53 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: cluster-machinepools
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machinePools:
+      - name: controlPlanePool
+        controlPlaneRole: true
+        etcdRole: true
+        workerRole: false
+        quantity: 3
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorControlPlanes
+      - name: workersPool
+        controlPlaneRole: false
+        etcdRole: false
+        workerRole: true
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorWorkers
+  kubernetesVersion: v1.23.7+k3s1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorControlPlanes
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorWorkers
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-2

--- a/versioned_docs/version-1.4/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
+++ b/versioned_docs/version-1.4/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: test-machine
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: password
+      # add your custom cloud-config snippets to customize your system
+      write_files:
+        - content: V2h5IGFyZSB5b3UgY2hlY2tpbmcgdGhpcz8K
+          encoding: b64
+          path: /etc/custom.file
+    elemental:
+      install:
+        reboot: true
+        device: /dev/vda
+        iso: https://something.example.com
+  machineInventoryLabels:
+    clusterName: test

--- a/versioned_docs/version-1.4/examples/network/machineregistration-nmc.yaml
+++ b/versioned_docs/version-1.4/examples/network/machineregistration-nmc.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.4/examples/network/machineregistration-nmconnections.yaml
+++ b/versioned_docs/version-1.4/examples/network/machineregistration-nmconnections.yaml
@@ -1,0 +1,65 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: test-${System Information/UUID}
+  config:
+    network:
+      configurator: "nmconnections"
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        enp1s0: |
+          [connection]
+          id=Wired connection 1
+          type=ethernet
+          interface-name=enp1s0
+          [ipv4]
+          address1={inventory-ip}/24,192.168.1.1
+          dns=192.168.122.1;
+          method=manual
+          route1=0.0.0.0/0,192.168.122.1
+          [ipv6]
+          method=disabled
+        enp8s0: |
+          [connection]
+          id=Wired connection 2
+          type=ethernet
+          interface-name=enp8s0
+          [ipv4]
+          address1={secondary-ip}/24,172.16.0.1
+          method=manual
+          route1=172.16.0.0/24,172.16.0.1,150
+          [ipv6]
+          method=disabled

--- a/versioned_docs/version-1.4/examples/network/machineregistration-nmstate.yaml
+++ b/versioned_docs/version-1.4/examples/network/machineregistration-nmstate.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmstate
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.4/examples/network/machineregistration.yaml
+++ b/versioned_docs/version-1.4/examples/network/machineregistration.yaml
@@ -1,0 +1,52 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.4/examples/network/yip-nmc-static-config.yaml
+++ b/versioned_docs/version-1.4/examples/network/yip-nmc-static-config.yaml
@@ -1,0 +1,78 @@
+name: Static nm-configurator config
+stages:
+  initramfs:
+  - directories:
+      - path: /tmp/nmc/static/desired-states
+        permissions: 448
+        owner: 0
+        group: 0
+      - path: /tmp/nmc/static/network-config
+        permissions: 448
+        owner: 0
+        group: 0
+    files:
+      - path: /tmp/nmc/static/desired-states/node1.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:45:14:c5
+            ipv4:
+              address:
+              - ip: 192.168.122.150
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+      - path: /tmp/nmc/static/desired-states/node2.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:3a:ae:3b
+            ipv4:
+              address:
+              - ip: 192.168.122.151
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+    commands:
+    - nmc generate --config-dir /tmp/nmc/static/desired-states --output-dir /tmp/nmc/static/network-config
+    - nmc apply --config-dir /tmp/nmc/static/network-config

--- a/versioned_docs/version-1.4/examples/proxy/cluster-proxy.yaml
+++ b/versioned_docs/version-1.4/examples/proxy/cluster-proxy.yaml
@@ -1,0 +1,33 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: my-cluster
+  namespace: fleet-default
+spec:
+  agentEnvVars:
+  - name: HTTP_PROXY
+    value: http://<MY_PROXY>:<MY_PORT>
+  - name: HTTPS_PROXY
+    value: https://<MY_PROXY>:<MY_PORT>
+  - name: NO_PROXY
+    value: localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: my-machine-selector
+        name: pool1
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.4/examples/proxy/registration-proxy.yaml
+++ b/versioned_docs/version-1.4/examples/proxy/registration-proxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      write_files:
+      - path: /etc/sysconfig/proxy
+        append: true
+        content: |
+          PROXY_ENABLED="yes"
+          HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+          HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+          NO_PROXY="localhost, 127.0.0.1"
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true

--- a/versioned_docs/version-1.4/examples/proxy/seedimage-proxy.yaml
+++ b/versioned_docs/version-1.4/examples/proxy/seedimage-proxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: ...
+  namespace: ...
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  cloud-config:
+    write_files:
+    - path: /etc/sysconfig/proxy
+      append: true
+      content: |
+        PROXY_ENABLED="yes"
+        HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+        HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+        NO_PROXY="localhost, 127.0.0.1"
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: ...
+    namespace: ...

--- a/versioned_docs/version-1.4/examples/quickstart/cluster.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/cluster.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: volcano
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: fire-machine-selector
+        name: fire-pool
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.4/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  machineName: "${System Data/Runtime/Hostname}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.4/examples/quickstart/registration-hardware.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/registration-hardware.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.4/examples/quickstart/registration-random-hostname.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/registration-random-hostname.yaml
@@ -1,0 +1,19 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: "fire-node-${Random/Hex/12}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/UUID: "${Random/UUID}"

--- a/versioned_docs/version-1.4/examples/quickstart/registration-tpm.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/registration-tpm.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.4/examples/quickstart/registration.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/registration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.4/examples/quickstart/rpi-registration.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/rpi-registration.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/mmcblk0
+        debug: true
+        disable-boot-entry: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.4/examples/quickstart/seedimage.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/seedimage.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: fire-img
+  namespace: fleet-default
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: fire-nodes
+    namespace: fleet-default

--- a/versioned_docs/version-1.4/examples/quickstart/selector.yaml
+++ b/versioned_docs/version-1.4/examples/quickstart/selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: fire-machine-selector
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchExpressions:
+          - key: element
+            operator: In
+            values: [ 'fire' ]

--- a/versioned_docs/version-1.4/examples/upgrade/managed-os-version-channel-custom.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/managed-os-version-channel-custom.yaml
@@ -1,0 +1,9 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-channel
+  namespace: fleet-default
+spec:
+  options:
+    image: registry.suse.com/rancher/elemental-channel:latest
+  type: custom

--- a/versioned_docs/version-1.4/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/managed-os-version-channel-json.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-versions
+  namespace: fleet-default
+spec:
+  options:
+    URI: "https://raw.githubusercontent.com/rancher/elemental-docs/main/examples/upgrade/versions.json"
+    Timeout: "1m"
+  type: json

--- a/versioned_docs/version-1.4/examples/upgrade/upgrade-cluster-target.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/upgrade-cluster-target.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to or track the latest tag
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.4/examples/upgrade/upgrade-force.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/upgrade-force.yaml
@@ -1,0 +1,14 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      - name: FORCE
+        value: "true"

--- a/versioned_docs/version-1.4/examples/upgrade/upgrade-managedos-version.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/upgrade-managedos-version.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name:  my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new ManagedOSVersion you would like to upgrade to
+  managedOSVersionName: v0.1.0-alpha22-amd64
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.4/examples/upgrade/upgrade-node-selector.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/upgrade-node-selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: my-machine

--- a/versioned_docs/version-1.4/examples/upgrade/upgrade-recovery.yaml
+++ b/versioned_docs/version-1.4/examples/upgrade/upgrade-recovery.yaml
@@ -1,0 +1,18 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade-recovery
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      # Use UPGRADE_RECOVERY_ONLY to upgrade the recovery partition only. (This has the same effect as FORCE="true")
+      - name: UPGRADE_RECOVERY_ONLY
+        value: "false"
+      # Use UPGRADE_RECOVERY to upgrade both system and recovery partitions.
+      - name: UPGRADE_RECOVERY
+        value: "true"

--- a/versioned_docs/version-1.4/examples/upgrade/versions.json
+++ b/versioned_docs/version-1.4/examples/upgrade/versions.json
@@ -1,0 +1,28 @@
+[
+  {
+      "metadata": {
+          "name": "my-flavor-v0.1.0"
+      },
+      "spec": {
+          "version": "v0.1.0",
+          "type": "container",
+          "metadata": {
+              "upgradeImage": "foo/bar-os:v0.1.0-myflavor",
+              "displayName": "Foo Bar OS - My Flavor"
+          }
+      }
+  },
+  {
+    "metadata": {
+        "name": "my-flavor-v0.1.0-iso"
+    },
+    "spec": {
+        "version": "v0.1.0",
+        "type": "iso",
+        "metadata": {
+            "uri": "foo/bar-iso:v0.1.0-myflavor",
+            "displayName": "Foo Bar ISO - My Flavor"
+        }
+    }
+  }
+]

--- a/versioned_docs/version-1.4/hardwarelabels.md
+++ b/versioned_docs/version-1.4/hardwarelabels.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware-dhcphostname.yaml"
 
 ## Hardware Labels
 

--- a/versioned_docs/version-1.4/hostname.md
+++ b/versioned_docs/version-1.4/hostname.md
@@ -53,7 +53,7 @@ registering host will be successful while the others will fail: the `MachineInve
 unique.
 :::
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware-dhcphostname.yaml"
 
 ### Keep the hostname assigned from DHCP
 In order to keep the hostname assigned from the DHCP server before the host registers to the operator,

--- a/versioned_docs/version-1.4/managedosimage-reference.md
+++ b/versioned_docs/version-1.4/managedosimage-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/managedosimage-reference"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
 
 # ManagedOSImage reference
 

--- a/versioned_docs/version-1.4/quickstart-cli.md
+++ b/versioned_docs/version-1.4/quickstart-cli.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # Elemental the command line way
 

--- a/versioned_docs/version-1.4/quickstart-ui.md
+++ b/versioned_docs/version-1.4/quickstart-ui.md
@@ -7,10 +7,10 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 
 # Elemental the visual way
 

--- a/versioned_docs/version-1.4/smbios.md
+++ b/versioned_docs/version-1.4/smbios.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.4/tpm.md
+++ b/versioned_docs/version-1.4/tpm.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
 </head>
 
-import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+import RegistrationTpm from "!!raw-loader!./examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)
 

--- a/versioned_docs/version-1.4/upgrade.md
+++ b/versioned_docs/version-1.4/upgrade.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
-import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
-import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"
-import ManagedOSVersion from "!!raw-loader!@site/examples/upgrade/upgrade-managedos-version.yaml"
-import MangedOSVersionChannelJson from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-json.yaml"
-import ManagedOSVersionChannelCustom from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-custom.yaml"
-import Versions from "../examples/upgrade/versions.raw!=!raw-loader!@site/examples/upgrade/versions.json"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
+import NodeSelector from "!!raw-loader!./examples/upgrade/upgrade-node-selector.yaml"
+import UpgradeForce from "!!raw-loader!./examples/upgrade/upgrade-force.yaml"
+import ManagedOSVersion from "!!raw-loader!./examples/upgrade/upgrade-managedos-version.yaml"
+import MangedOSVersionChannelJson from "!!raw-loader!./examples/upgrade/managed-os-version-channel-json.yaml"
+import ManagedOSVersionChannelCustom from "!!raw-loader!./examples/upgrade/managed-os-version-channel-custom.yaml"
+import Versions from "../examples/upgrade/versions.raw!=!raw-loader!./examples/upgrade/versions.json"
 
 # Upgrade
 

--- a/versioned_docs/version-1.5/authentication.md
+++ b/versioned_docs/version-1.5/authentication.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/authentication"/>
 </head>
 
-import RegistrationEmulateTpm from "!!raw-loader!@site/examples/authentication/registration-emulate-tpm.yaml"
-import RegistrationMac from "!!raw-loader!@site/examples/authentication/registration-mac.yaml"
-import RegistrationSysUUID from "!!raw-loader!@site/examples/authentication/registration-sys-uuid.yaml"
+import RegistrationEmulateTpm from "!!raw-loader!./examples/authentication/registration-emulate-tpm.yaml"
+import RegistrationMac from "!!raw-loader!./examples/authentication/registration-mac.yaml"
+import RegistrationSysUUID from "!!raw-loader!./examples/authentication/registration-sys-uuid.yaml"
 
 # Authentication
 

--- a/versioned_docs/version-1.5/cluster-reference.md
+++ b/versioned_docs/version-1.5/cluster-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
 </head>
 
-import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
+import Machinepools from "!!raw-loader!./examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference
 

--- a/versioned_docs/version-1.5/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.5/elemental_behind_proxy.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
 </head>
 
-import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
-import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
-import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"
+import RegistrationProxy from "!!raw-loader!./examples/proxy/registration-proxy.yaml"
+import SeedimageProxy from "!!raw-loader!./examples/proxy/seedimage-proxy.yaml"
+import ClusterProxy from "!!raw-loader!./examples/proxy/cluster-proxy.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.5/examples/authentication/registration-emulate-tpm.yaml
+++ b/versioned_docs/version-1.5/examples/authentication/registration-emulate-tpm.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+        emulated-tpm-seed: -1
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.5/examples/authentication/registration-mac.yaml
+++ b/versioned_docs/version-1.5/examples/authentication/registration-mac.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: mac
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.5/examples/authentication/registration-sys-uuid.yaml
+++ b/versioned_docs/version-1.5/examples/authentication/registration-sys-uuid.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: sys-uuid
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.5/examples/clusters/clusters-several-machinepools.yml
+++ b/versioned_docs/version-1.5/examples/clusters/clusters-several-machinepools.yml
@@ -1,0 +1,53 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: cluster-machinepools
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machinePools:
+      - name: controlPlanePool
+        controlPlaneRole: true
+        etcdRole: true
+        workerRole: false
+        quantity: 3
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorControlPlanes
+      - name: workersPool
+        controlPlaneRole: false
+        etcdRole: false
+        workerRole: true
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorWorkers
+  kubernetesVersion: v1.23.7+k3s1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorControlPlanes
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorWorkers
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-2

--- a/versioned_docs/version-1.5/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
+++ b/versioned_docs/version-1.5/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: test-machine
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: password
+      # add your custom cloud-config snippets to customize your system
+      write_files:
+        - content: V2h5IGFyZSB5b3UgY2hlY2tpbmcgdGhpcz8K
+          encoding: b64
+          path: /etc/custom.file
+    elemental:
+      install:
+        reboot: true
+        device: /dev/vda
+        iso: https://something.example.com
+  machineInventoryLabels:
+    clusterName: test

--- a/versioned_docs/version-1.5/examples/network/machineregistration-nmc.yaml
+++ b/versioned_docs/version-1.5/examples/network/machineregistration-nmc.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.5/examples/network/machineregistration-nmconnections.yaml
+++ b/versioned_docs/version-1.5/examples/network/machineregistration-nmconnections.yaml
@@ -1,0 +1,65 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: test-${System Information/UUID}
+  config:
+    network:
+      configurator: "nmconnections"
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        enp1s0: |
+          [connection]
+          id=Wired connection 1
+          type=ethernet
+          interface-name=enp1s0
+          [ipv4]
+          address1={inventory-ip}/24,192.168.1.1
+          dns=192.168.122.1;
+          method=manual
+          route1=0.0.0.0/0,192.168.122.1
+          [ipv6]
+          method=disabled
+        enp8s0: |
+          [connection]
+          id=Wired connection 2
+          type=ethernet
+          interface-name=enp8s0
+          [ipv4]
+          address1={secondary-ip}/24,172.16.0.1
+          method=manual
+          route1=172.16.0.0/24,172.16.0.1,150
+          [ipv6]
+          method=disabled

--- a/versioned_docs/version-1.5/examples/network/machineregistration-nmstate.yaml
+++ b/versioned_docs/version-1.5/examples/network/machineregistration-nmstate.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmstate
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.5/examples/network/machineregistration.yaml
+++ b/versioned_docs/version-1.5/examples/network/machineregistration.yaml
@@ -1,0 +1,52 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.5/examples/network/yip-nmc-static-config.yaml
+++ b/versioned_docs/version-1.5/examples/network/yip-nmc-static-config.yaml
@@ -1,0 +1,78 @@
+name: Static nm-configurator config
+stages:
+  initramfs:
+  - directories:
+      - path: /tmp/nmc/static/desired-states
+        permissions: 448
+        owner: 0
+        group: 0
+      - path: /tmp/nmc/static/network-config
+        permissions: 448
+        owner: 0
+        group: 0
+    files:
+      - path: /tmp/nmc/static/desired-states/node1.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:45:14:c5
+            ipv4:
+              address:
+              - ip: 192.168.122.150
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+      - path: /tmp/nmc/static/desired-states/node2.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:3a:ae:3b
+            ipv4:
+              address:
+              - ip: 192.168.122.151
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+    commands:
+    - nmc generate --config-dir /tmp/nmc/static/desired-states --output-dir /tmp/nmc/static/network-config
+    - nmc apply --config-dir /tmp/nmc/static/network-config

--- a/versioned_docs/version-1.5/examples/proxy/cluster-proxy.yaml
+++ b/versioned_docs/version-1.5/examples/proxy/cluster-proxy.yaml
@@ -1,0 +1,33 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: my-cluster
+  namespace: fleet-default
+spec:
+  agentEnvVars:
+  - name: HTTP_PROXY
+    value: http://<MY_PROXY>:<MY_PORT>
+  - name: HTTPS_PROXY
+    value: https://<MY_PROXY>:<MY_PORT>
+  - name: NO_PROXY
+    value: localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: my-machine-selector
+        name: pool1
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.5/examples/proxy/registration-proxy.yaml
+++ b/versioned_docs/version-1.5/examples/proxy/registration-proxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      write_files:
+      - path: /etc/sysconfig/proxy
+        append: true
+        content: |
+          PROXY_ENABLED="yes"
+          HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+          HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+          NO_PROXY="localhost, 127.0.0.1"
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true

--- a/versioned_docs/version-1.5/examples/proxy/seedimage-proxy.yaml
+++ b/versioned_docs/version-1.5/examples/proxy/seedimage-proxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: ...
+  namespace: ...
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  cloud-config:
+    write_files:
+    - path: /etc/sysconfig/proxy
+      append: true
+      content: |
+        PROXY_ENABLED="yes"
+        HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+        HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+        NO_PROXY="localhost, 127.0.0.1"
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: ...
+    namespace: ...

--- a/versioned_docs/version-1.5/examples/quickstart/cluster.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/cluster.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: volcano
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: fire-machine-selector
+        name: fire-pool
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.5/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  machineName: "${System Data/Runtime/Hostname}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.5/examples/quickstart/registration-hardware.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/registration-hardware.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.5/examples/quickstart/registration-random-hostname.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/registration-random-hostname.yaml
@@ -1,0 +1,19 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: "fire-node-${Random/Hex/12}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/UUID: "${Random/UUID}"

--- a/versioned_docs/version-1.5/examples/quickstart/registration-tpm.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/registration-tpm.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.5/examples/quickstart/registration.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/registration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.5/examples/quickstart/rpi-registration.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/rpi-registration.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/mmcblk0
+        debug: true
+        disable-boot-entry: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.5/examples/quickstart/seedimage.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/seedimage.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: fire-img
+  namespace: fleet-default
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: fire-nodes
+    namespace: fleet-default

--- a/versioned_docs/version-1.5/examples/quickstart/selector.yaml
+++ b/versioned_docs/version-1.5/examples/quickstart/selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: fire-machine-selector
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchExpressions:
+          - key: element
+            operator: In
+            values: [ 'fire' ]

--- a/versioned_docs/version-1.5/examples/upgrade/managed-os-version-channel-custom.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/managed-os-version-channel-custom.yaml
@@ -1,0 +1,9 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-channel
+  namespace: fleet-default
+spec:
+  options:
+    image: registry.suse.com/rancher/elemental-channel:latest
+  type: custom

--- a/versioned_docs/version-1.5/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/managed-os-version-channel-json.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-versions
+  namespace: fleet-default
+spec:
+  options:
+    URI: "https://raw.githubusercontent.com/rancher/elemental-docs/main/examples/upgrade/versions.json"
+    Timeout: "1m"
+  type: json

--- a/versioned_docs/version-1.5/examples/upgrade/upgrade-cluster-target.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/upgrade-cluster-target.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to or track the latest tag
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.5/examples/upgrade/upgrade-force.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/upgrade-force.yaml
@@ -1,0 +1,14 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      - name: FORCE
+        value: "true"

--- a/versioned_docs/version-1.5/examples/upgrade/upgrade-managedos-version.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/upgrade-managedos-version.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name:  my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new ManagedOSVersion you would like to upgrade to
+  managedOSVersionName: v0.1.0-alpha22-amd64
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.5/examples/upgrade/upgrade-node-selector.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/upgrade-node-selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: my-machine

--- a/versioned_docs/version-1.5/examples/upgrade/upgrade-recovery.yaml
+++ b/versioned_docs/version-1.5/examples/upgrade/upgrade-recovery.yaml
@@ -1,0 +1,18 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade-recovery
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      # Use UPGRADE_RECOVERY_ONLY to upgrade the recovery partition only. (This has the same effect as FORCE="true")
+      - name: UPGRADE_RECOVERY_ONLY
+        value: "false"
+      # Use UPGRADE_RECOVERY to upgrade both system and recovery partitions.
+      - name: UPGRADE_RECOVERY
+        value: "true"

--- a/versioned_docs/version-1.5/examples/upgrade/versions.json
+++ b/versioned_docs/version-1.5/examples/upgrade/versions.json
@@ -1,0 +1,28 @@
+[
+  {
+      "metadata": {
+          "name": "my-flavor-v0.1.0"
+      },
+      "spec": {
+          "version": "v0.1.0",
+          "type": "container",
+          "metadata": {
+              "upgradeImage": "foo/bar-os:v0.1.0-myflavor",
+              "displayName": "Foo Bar OS - My Flavor"
+          }
+      }
+  },
+  {
+    "metadata": {
+        "name": "my-flavor-v0.1.0-iso"
+    },
+    "spec": {
+        "version": "v0.1.0",
+        "type": "iso",
+        "metadata": {
+            "uri": "foo/bar-iso:v0.1.0-myflavor",
+            "displayName": "Foo Bar ISO - My Flavor"
+        }
+    }
+  }
+]

--- a/versioned_docs/version-1.5/hardwarelabels.md
+++ b/versioned_docs/version-1.5/hardwarelabels.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware-dhcphostname.yaml"
 
 ## Hardware Labels
 

--- a/versioned_docs/version-1.5/hostname.md
+++ b/versioned_docs/version-1.5/hostname.md
@@ -51,7 +51,7 @@ registering host will be successful while the others will fail: the `MachineInve
 unique.
 :::
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware-dhcphostname.yaml"
 
 ### Keep the hostname assigned from DHCP
 In order to keep the hostname assigned from the DHCP server before the host registers to the operator,

--- a/versioned_docs/version-1.5/managedosimage-reference.md
+++ b/versioned_docs/version-1.5/managedosimage-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/managedosimage-reference"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
 
 # ManagedOSImage reference
 

--- a/versioned_docs/version-1.5/quickstart-cli.md
+++ b/versioned_docs/version-1.5/quickstart-cli.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # Elemental the command line way
 

--- a/versioned_docs/version-1.5/quickstart-ui.md
+++ b/versioned_docs/version-1.5/quickstart-ui.md
@@ -7,10 +7,10 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 
 # Elemental the visual way
 

--- a/versioned_docs/version-1.5/rancher-vmware.md
+++ b/versioned_docs/version-1.5/rancher-vmware.md
@@ -7,8 +7,8 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/rancher-vmware"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # How to use Elemental with Rancher and VMware
 

--- a/versioned_docs/version-1.5/smbios.md
+++ b/versioned_docs/version-1.5/smbios.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.5/tpm.md
+++ b/versioned_docs/version-1.5/tpm.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
 </head>
 
-import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+import RegistrationTpm from "!!raw-loader!./examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)
 

--- a/versioned_docs/version-1.5/upgrade.md
+++ b/versioned_docs/version-1.5/upgrade.md
@@ -7,14 +7,14 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
-import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
-import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"
-import UpgradeRecovery from "!!raw-loader!@site/examples/upgrade/upgrade-recovery.yaml"
-import ManagedOSVersion from "!!raw-loader!@site/examples/upgrade/upgrade-managedos-version.yaml"
-import MangedOSVersionChannelJson from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-json.yaml"
-import ManagedOSVersionChannelCustom from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-custom.yaml"
-import Versions from "../examples/upgrade/versions.raw!=!raw-loader!@site/examples/upgrade/versions.json"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
+import NodeSelector from "!!raw-loader!./examples/upgrade/upgrade-node-selector.yaml"
+import UpgradeForce from "!!raw-loader!./examples/upgrade/upgrade-force.yaml"
+import UpgradeRecovery from "!!raw-loader!./examples/upgrade/upgrade-recovery.yaml"
+import ManagedOSVersion from "!!raw-loader!./examples/upgrade/upgrade-managedos-version.yaml"
+import MangedOSVersionChannelJson from "!!raw-loader!./examples/upgrade/managed-os-version-channel-json.yaml"
+import ManagedOSVersionChannelCustom from "!!raw-loader!./examples/upgrade/managed-os-version-channel-custom.yaml"
+import Versions from "../examples/upgrade/versions.raw!=!raw-loader!./examples/upgrade/versions.json"
 
 # Upgrade
 

--- a/versioned_docs/version-1.6/authentication.md
+++ b/versioned_docs/version-1.6/authentication.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/authentication"/>
 </head>
 
-import RegistrationEmulateTpm from "!!raw-loader!@site/examples/authentication/registration-emulate-tpm.yaml"
-import RegistrationMac from "!!raw-loader!@site/examples/authentication/registration-mac.yaml"
-import RegistrationSysUUID from "!!raw-loader!@site/examples/authentication/registration-sys-uuid.yaml"
+import RegistrationEmulateTpm from "!!raw-loader!./examples/authentication/registration-emulate-tpm.yaml"
+import RegistrationMac from "!!raw-loader!./examples/authentication/registration-mac.yaml"
+import RegistrationSysUUID from "!!raw-loader!./examples/authentication/registration-sys-uuid.yaml"
 
 # Authentication
 

--- a/versioned_docs/version-1.6/channels.md
+++ b/versioned_docs/version-1.6/channels.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/channels"/>
 </head>
 
-import MangedOSVersionChannelJson from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-json.yaml"
-import ManagedOSVersionChannelCustom from "!!raw-loader!@site/examples/upgrade/managed-os-version-channel-custom.yaml"
-import Versions from "../examples/upgrade/versions.raw!=!raw-loader!@site/examples/upgrade/versions.json"
+import MangedOSVersionChannelJson from "!!raw-loader!./examples/upgrade/managed-os-version-channel-json.yaml"
+import ManagedOSVersionChannelCustom from "!!raw-loader!./examples/upgrade/managed-os-version-channel-custom.yaml"
+import Versions from "../examples/upgrade/versions.raw!=!raw-loader!./examples/upgrade/versions.json"
 
 ## Channels
 

--- a/versioned_docs/version-1.6/cluster-reference.md
+++ b/versioned_docs/version-1.6/cluster-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/cluster-reference"/>
 </head>
 
-import Machinepools from "!!raw-loader!@site/examples/clusters/clusters-several-machinepools.yml"
+import Machinepools from "!!raw-loader!./examples/clusters/clusters-several-machinepools.yml"
 
 # Cluster reference
 

--- a/versioned_docs/version-1.6/elemental_behind_proxy.md
+++ b/versioned_docs/version-1.6/elemental_behind_proxy.md
@@ -7,9 +7,9 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/elemental_behind_proxy"/>
 </head>
 
-import RegistrationProxy from "!!raw-loader!@site/examples/proxy/registration-proxy.yaml"
-import SeedimageProxy from "!!raw-loader!@site/examples/proxy/seedimage-proxy.yaml"
-import ClusterProxy from "!!raw-loader!@site/examples/proxy/cluster-proxy.yaml"
+import RegistrationProxy from "!!raw-loader!./examples/proxy/registration-proxy.yaml"
+import SeedimageProxy from "!!raw-loader!./examples/proxy/seedimage-proxy.yaml"
+import ClusterProxy from "!!raw-loader!./examples/proxy/cluster-proxy.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.6/examples/authentication/registration-emulate-tpm.yaml
+++ b/versioned_docs/version-1.6/examples/authentication/registration-emulate-tpm.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+        emulated-tpm-seed: -1
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.6/examples/authentication/registration-mac.yaml
+++ b/versioned_docs/version-1.6/examples/authentication/registration-mac.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: mac
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.6/examples/authentication/registration-sys-uuid.yaml
+++ b/versioned_docs/version-1.6/examples/authentication/registration-sys-uuid.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-mac
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        auth: sys-uuid
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.6/examples/clusters/clusters-several-machinepools.yml
+++ b/versioned_docs/version-1.6/examples/clusters/clusters-several-machinepools.yml
@@ -1,0 +1,53 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: cluster-machinepools
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machinePools:
+      - name: controlPlanePool
+        controlPlaneRole: true
+        etcdRole: true
+        workerRole: false
+        quantity: 3
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorControlPlanes
+      - name: workersPool
+        controlPlaneRole: false
+        etcdRole: false
+        workerRole: true
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: selectorWorkers
+  kubernetesVersion: v1.23.7+k3s1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorControlPlanes
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: selectorWorkers
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchLabels:
+          location: server-room-2

--- a/versioned_docs/version-1.6/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
+++ b/versioned_docs/version-1.6/examples/elemental.cattle.io/v1beta1/MachineRegistration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: test-machine
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: password
+      # add your custom cloud-config snippets to customize your system
+      write_files:
+        - content: V2h5IGFyZSB5b3UgY2hlY2tpbmcgdGhpcz8K
+          encoding: b64
+          path: /etc/custom.file
+    elemental:
+      install:
+        reboot: true
+        device: /dev/vda
+        iso: https://something.example.com
+  machineInventoryLabels:
+    clusterName: test

--- a/versioned_docs/version-1.6/examples/network/machineregistration-nmc.yaml
+++ b/versioned_docs/version-1.6/examples/network/machineregistration-nmc.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.6/examples/network/machineregistration-nmconnections.yaml
+++ b/versioned_docs/version-1.6/examples/network/machineregistration-nmconnections.yaml
@@ -1,0 +1,65 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: test-${System Information/UUID}
+  config:
+    network:
+      configurator: "nmconnections"
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        enp1s0: |
+          [connection]
+          id=Wired connection 1
+          type=ethernet
+          interface-name=enp1s0
+          [ipv4]
+          address1={inventory-ip}/24,192.168.1.1
+          dns=192.168.122.1;
+          method=manual
+          route1=0.0.0.0/0,192.168.122.1
+          [ipv6]
+          method=disabled
+        enp8s0: |
+          [connection]
+          id=Wired connection 2
+          type=ethernet
+          interface-name=enp8s0
+          [ipv4]
+          address1={secondary-ip}/24,172.16.0.1
+          method=manual
+          route1=172.16.0.0/24,172.16.0.1,150
+          [ipv6]
+          method=disabled

--- a/versioned_docs/version-1.6/examples/network/machineregistration-nmstate.yaml
+++ b/versioned_docs/version-1.6/examples/network/machineregistration-nmstate.yaml
@@ -1,0 +1,84 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-secondary-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 172.16.0.150-172.16.0.200
+  prefix: 24
+  gateway: 172.16.0.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmstate
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+        secondary-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-secondary-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+          - destination: 172.16.0.1/24
+            next-hop-interface: enp8s0
+            next-hop-address: 172.16.0.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false
+          - name: enp8s0
+            type: ethernet
+            description: Secondary-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{secondary-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.6/examples/network/machineregistration.yaml
+++ b/versioned_docs/version-1.6/examples/network/machineregistration.yaml
@@ -1,0 +1,52 @@
+apiVersion: ipam.cluster.x-k8s.io/v1alpha2
+kind: InClusterIPPool
+metadata:
+  name: elemental-inventory-pool
+  namespace: fleet-default
+spec:
+  addresses:
+    - 192.168.122.150-192.168.122.200
+  prefix: 24
+  gateway: 192.168.122.1
+---
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: m-${System Information/UUID}
+  config:
+    network:
+      configurator: nmc
+      ipAddresses:
+        inventory-ip:
+          apiGroup: ipam.cluster.x-k8s.io
+          kind: InClusterIPPool
+          name: elemental-inventory-pool
+      config:
+        dns-resolver:
+          config:
+            server:
+            - 192.168.122.1
+            search: []
+        routes:
+          config:
+          - destination: 0.0.0.0/0
+            next-hop-interface: enp1s0
+            next-hop-address: 192.168.122.1
+            metric: 150
+            table-id: 254
+        interfaces:
+          - name: enp1s0
+            type: ethernet
+            description: Main-NIC
+            state: up
+            ipv4:
+              enabled: true
+              dhcp: false
+              address:
+              - ip: "{inventory-ip}"
+                prefix-length: 24
+            ipv6:
+              enabled: false

--- a/versioned_docs/version-1.6/examples/network/yip-nmc-static-config.yaml
+++ b/versioned_docs/version-1.6/examples/network/yip-nmc-static-config.yaml
@@ -1,0 +1,78 @@
+name: Static nm-configurator config
+stages:
+  initramfs:
+  - directories:
+      - path: /tmp/nmc/static/desired-states
+        permissions: 448
+        owner: 0
+        group: 0
+      - path: /tmp/nmc/static/network-config
+        permissions: 448
+        owner: 0
+        group: 0
+    files:
+      - path: /tmp/nmc/static/desired-states/node1.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:45:14:c5
+            ipv4:
+              address:
+              - ip: 192.168.122.150
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+      - path: /tmp/nmc/static/desired-states/node2.yaml
+        permissions: 384
+        owner: 0
+        group: 0
+        content: |
+          dns-resolver:
+            config:
+              server:
+              - 192.168.122.1
+              search: []
+          routes:
+            config:
+            - destination: 0.0.0.0/0
+              next-hop-interface: enp1s0
+              next-hop-address: 192.168.122.1
+              metric: 150
+              table-id: 254
+          interfaces:
+          - name: enp1s0
+            type: ethernet
+            state: up
+            mac-address: 52:54:00:3a:ae:3b
+            ipv4:
+              address:
+              - ip: 192.168.122.151
+                prefix-length: 24
+              enabled: true
+            ipv6:
+              enabled: false
+        encoding: ""
+        ownerstring: ""
+    commands:
+    - nmc generate --config-dir /tmp/nmc/static/desired-states --output-dir /tmp/nmc/static/network-config
+    - nmc apply --config-dir /tmp/nmc/static/network-config

--- a/versioned_docs/version-1.6/examples/proxy/cluster-proxy.yaml
+++ b/versioned_docs/version-1.6/examples/proxy/cluster-proxy.yaml
@@ -1,0 +1,33 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: my-cluster
+  namespace: fleet-default
+spec:
+  agentEnvVars:
+  - name: HTTP_PROXY
+    value: http://<MY_PROXY>:<MY_PORT>
+  - name: HTTPS_PROXY
+    value: https://<MY_PROXY>:<MY_PORT>
+  - name: NO_PROXY
+    value: localhost,127.0.0.0/8,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: my-machine-selector
+        name: pool1
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.6/examples/proxy/registration-proxy.yaml
+++ b/versioned_docs/version-1.6/examples/proxy/registration-proxy.yaml
@@ -1,0 +1,26 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      write_files:
+      - path: /etc/sysconfig/proxy
+        append: true
+        content: |
+          PROXY_ENABLED="yes"
+          HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+          HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+          NO_PROXY="localhost, 127.0.0.1"
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true

--- a/versioned_docs/version-1.6/examples/proxy/seedimage-proxy.yaml
+++ b/versioned_docs/version-1.6/examples/proxy/seedimage-proxy.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: ...
+  namespace: ...
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  cloud-config:
+    write_files:
+    - path: /etc/sysconfig/proxy
+      append: true
+      content: |
+        PROXY_ENABLED="yes"
+        HTTP_PROXY=http://<MY_PROXY>:<MY_PORT>
+        HTTPS_PROXY=https://<MY_PROXY>:<MY_PORT>
+        NO_PROXY="localhost, 127.0.0.1"
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: ...
+    namespace: ...

--- a/versioned_docs/version-1.6/examples/quickstart/cluster.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/cluster.yaml
@@ -1,0 +1,26 @@
+kind: Cluster
+apiVersion: provisioning.cattle.io/v1
+metadata:
+  name: volcano
+  namespace: fleet-default
+spec:
+  rkeConfig:
+    machineGlobalConfig:
+      etcd-expose-metrics: false
+      profile: null
+    machinePools:
+      - controlPlaneRole: true
+        etcdRole: true
+        machineConfigRef:
+          apiVersion: elemental.cattle.io/v1beta1
+          kind: MachineInventorySelectorTemplate
+          name: fire-machine-selector
+        name: fire-pool
+        quantity: 1
+        unhealthyNodeTimeout: 0s
+        workerRole: true
+    machineSelectorConfig:
+      - config:
+          protect-kernel-defaults: false
+    registries: {}
+  kubernetesVersion: v1.24.8+k3s1

--- a/versioned_docs/version-1.6/examples/quickstart/registration-hardware-dhcphostname.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/registration-hardware-dhcphostname.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  machineName: "${System Data/Runtime/Hostname}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.6/examples/quickstart/registration-hardware.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/registration-hardware.yaml
@@ -1,0 +1,21 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: my-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/CpuTotalCores: "${System Data/CPU/Total Cores}"
+    elemental.cattle.io/CpuTotalThreads: "${System Data/CPU/Total Threads}"
+    elemental.cattle.io/TotalMemoryBytes: "${System Data/Memory/Total Physical Bytes}"
+    elemental.cattle.io/NumberBlockDevices: "${System Data/Block Devices/Number Devices}"

--- a/versioned_docs/version-1.6/examples/quickstart/registration-random-hostname.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/registration-random-hostname.yaml
@@ -1,0 +1,19 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  machineName: "fire-node-${Random/Hex/12}"
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    elemental.cattle.io/UUID: "${Random/UUID}"

--- a/versioned_docs/version-1.6/examples/quickstart/registration-tpm.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/registration-tpm.yaml
@@ -1,0 +1,24 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes-emulate-tpm
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.6/examples/quickstart/registration.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/registration.yaml
@@ -1,0 +1,22 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/sda
+        debug: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.6/examples/quickstart/rpi-registration.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/rpi-registration.yaml
@@ -1,0 +1,25 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineRegistration
+metadata:
+  name: fire-nodes
+  namespace: fleet-default
+spec:
+  config:
+    cloud-config:
+      users:
+        - name: root
+          passwd: root
+    elemental:
+      install:
+        reboot: true
+        device: /dev/mmcblk0
+        debug: true
+        disable-boot-entry: true
+      registration:
+        emulate-tpm: true
+  machineInventoryLabels:
+    element: fire
+    manufacturer: "${System Information/Manufacturer}"
+    productName: "${System Information/Product Name}"
+    serialNumber: "${System Information/Serial Number}"
+    machineUUID: "${System Information/UUID}"

--- a/versioned_docs/version-1.6/examples/quickstart/seedimage.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/seedimage.yaml
@@ -1,0 +1,12 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: SeedImage
+metadata:
+  name: fire-img
+  namespace: fleet-default
+spec:
+  baseImage: registry.suse.com/suse/sle-micro-iso/5.5:2.0.2
+  registrationRef:
+    apiVersion: elemental.cattle.io/v1beta1
+    kind: MachineRegistration
+    name: fire-nodes
+    namespace: fleet-default

--- a/versioned_docs/version-1.6/examples/quickstart/selector.yaml
+++ b/versioned_docs/version-1.6/examples/quickstart/selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: MachineInventorySelectorTemplate
+metadata:
+  name: fire-machine-selector
+  namespace: fleet-default
+spec:
+  template:
+    spec:
+      selector:
+        matchExpressions:
+          - key: element
+            operator: In
+            values: [ 'fire' ]

--- a/versioned_docs/version-1.6/examples/upgrade/managed-os-version-channel-custom.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/managed-os-version-channel-custom.yaml
@@ -1,0 +1,9 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-channel
+  namespace: fleet-default
+spec:
+  options:
+    image: registry.suse.com/rancher/elemental-channel:latest
+  type: custom

--- a/versioned_docs/version-1.6/examples/upgrade/managed-os-version-channel-json.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/managed-os-version-channel-json.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSVersionChannel
+metadata:
+  name: elemental-versions
+  namespace: fleet-default
+spec:
+  options:
+    URI: "https://raw.githubusercontent.com/rancher/elemental-docs/main/examples/upgrade/versions.json"
+    Timeout: "1m"
+  type: json

--- a/versioned_docs/version-1.6/examples/upgrade/upgrade-cluster-target.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/upgrade-cluster-target.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to or track the latest tag
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.6/examples/upgrade/upgrade-force.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/upgrade-force.yaml
@@ -1,0 +1,14 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      - name: FORCE
+        value: "true"

--- a/versioned_docs/version-1.6/examples/upgrade/upgrade-managedos-version.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/upgrade-managedos-version.yaml
@@ -1,0 +1,10 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name:  my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new ManagedOSVersion you would like to upgrade to
+  managedOSVersionName: v0.1.0-alpha22-amd64
+  clusterTargets:
+    - clusterName: my-cluster

--- a/versioned_docs/version-1.6/examples/upgrade/upgrade-node-selector.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/upgrade-node-selector.yaml
@@ -1,0 +1,13 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  nodeSelector:
+    matchLabels:
+      kubernetes.io/hostname: my-machine

--- a/versioned_docs/version-1.6/examples/upgrade/upgrade-recovery.yaml
+++ b/versioned_docs/version-1.6/examples/upgrade/upgrade-recovery.yaml
@@ -1,0 +1,18 @@
+apiVersion: elemental.cattle.io/v1beta1
+kind: ManagedOSImage
+metadata:
+  name: my-upgrade-recovery
+  namespace: fleet-default
+spec:
+  # Set to the new Elemental version you would like to upgrade to
+  osImage: "registry.suse.com/suse/sle-micro/5.5:latest"
+  clusterTargets:
+    - clusterName: my-cluster
+  upgradeContainer:
+    envs:
+      # Use UPGRADE_RECOVERY_ONLY to upgrade the recovery partition only. (This has the same effect as FORCE="true")
+      - name: UPGRADE_RECOVERY_ONLY
+        value: "false"
+      # Use UPGRADE_RECOVERY to upgrade both system and recovery partitions.
+      - name: UPGRADE_RECOVERY
+        value: "true"

--- a/versioned_docs/version-1.6/examples/upgrade/versions.json
+++ b/versioned_docs/version-1.6/examples/upgrade/versions.json
@@ -1,0 +1,28 @@
+[
+  {
+      "metadata": {
+          "name": "my-flavor-v0.1.0"
+      },
+      "spec": {
+          "version": "v0.1.0",
+          "type": "container",
+          "metadata": {
+              "upgradeImage": "foo/bar-os:v0.1.0-myflavor",
+              "displayName": "Foo Bar OS - My Flavor"
+          }
+      }
+  },
+  {
+    "metadata": {
+        "name": "my-flavor-v0.1.0-iso"
+    },
+    "spec": {
+        "version": "v0.1.0",
+        "type": "iso",
+        "metadata": {
+            "uri": "foo/bar-iso:v0.1.0-myflavor",
+            "displayName": "Foo Bar ISO - My Flavor"
+        }
+    }
+  }
+]

--- a/versioned_docs/version-1.6/hardwarelabels.md
+++ b/versioned_docs/version-1.6/hardwarelabels.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/hardwarelabels"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware-dhcphostname.yaml"
 
 ## Hardware Labels
 

--- a/versioned_docs/version-1.6/hostname.md
+++ b/versioned_docs/version-1.6/hostname.md
@@ -51,7 +51,7 @@ registering host will be successful while the others will fail: the `MachineInve
 unique.
 :::
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration-hardware-dhcphostname.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration-hardware-dhcphostname.yaml"
 
 ### Keep the hostname assigned from DHCP
 In order to keep the hostname assigned from the DHCP server before the host registers to the operator,

--- a/versioned_docs/version-1.6/managedosimage-reference.md
+++ b/versioned_docs/version-1.6/managedosimage-reference.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/managedosimage-reference"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
 
 # ManagedOSImage reference
 

--- a/versioned_docs/version-1.6/networking-static.md
+++ b/versioned_docs/version-1.6/networking-static.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/networking"/>
 </head>
 
-import YipNmcStaticConfig from "!!raw-loader!@site/examples/network/yip-nmc-static-config.yaml"
+import YipNmcStaticConfig from "!!raw-loader!./examples/network/yip-nmc-static-config.yaml"
 
 ## Static Network with nm-configurator
 

--- a/versioned_docs/version-1.6/quickstart-cli.md
+++ b/versioned_docs/version-1.6/quickstart-cli.md
@@ -7,13 +7,13 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-cli"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 import Prereqs from './partials/_quickstart-prereqs.md'
 import Operator from './partials/_elemental-operator-install.md'
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # Elemental the command line way
 

--- a/versioned_docs/version-1.6/quickstart-ui.md
+++ b/versioned_docs/version-1.6/quickstart-ui.md
@@ -7,10 +7,10 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/quickstart-ui"/>
 </head>
 
-import Cluster from "!!raw-loader!@site/examples/quickstart/cluster.yaml"
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import RegistrationRPi from "!!raw-loader!@site/examples/quickstart/rpi-registration.yaml"
-import Selector from "!!raw-loader!@site/examples/quickstart/selector.yaml"
+import Cluster from "!!raw-loader!./examples/quickstart/cluster.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import RegistrationRPi from "!!raw-loader!./examples/quickstart/rpi-registration.yaml"
+import Selector from "!!raw-loader!./examples/quickstart/selector.yaml"
 
 # Elemental the visual way
 

--- a/versioned_docs/version-1.6/rancher-vmware.md
+++ b/versioned_docs/version-1.6/rancher-vmware.md
@@ -7,8 +7,8 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/rancher-vmware"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
-import SeedImage from "!!raw-loader!@site/examples/quickstart/seedimage.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
+import SeedImage from "!!raw-loader!./examples/quickstart/seedimage.yaml"
 
 # How to use Elemental with Rancher and VMware
 

--- a/versioned_docs/version-1.6/smbios.md
+++ b/versioned_docs/version-1.6/smbios.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/smbios"/>
 </head>
 
-import Registration from "!!raw-loader!@site/examples/quickstart/registration.yaml"
+import Registration from "!!raw-loader!./examples/quickstart/registration.yaml"
 
 ## Introduction
 

--- a/versioned_docs/version-1.6/tpm.md
+++ b/versioned_docs/version-1.6/tpm.md
@@ -7,7 +7,7 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/tpm"/>
 </head>
 
-import RegistrationTpm from "!!raw-loader!@site/examples/quickstart/registration-tpm.yaml"
+import RegistrationTpm from "!!raw-loader!./examples/quickstart/registration-tpm.yaml"
 
 # Trusted Platform Module 2.0 (TPM)
 

--- a/versioned_docs/version-1.6/upgrade.md
+++ b/versioned_docs/version-1.6/upgrade.md
@@ -7,11 +7,11 @@ title: ''
   <link rel="canonical" href="https://elemental.docs.rancher.com/upgrade"/>
 </head>
 
-import ClusterTarget from "!!raw-loader!@site/examples/upgrade/upgrade-cluster-target.yaml"
-import NodeSelector from "!!raw-loader!@site/examples/upgrade/upgrade-node-selector.yaml"
-import UpgradeForce from "!!raw-loader!@site/examples/upgrade/upgrade-force.yaml"
-import UpgradeRecovery from "!!raw-loader!@site/examples/upgrade/upgrade-recovery.yaml"
-import ManagedOSVersion from "!!raw-loader!@site/examples/upgrade/upgrade-managedos-version.yaml"
+import ClusterTarget from "!!raw-loader!./examples/upgrade/upgrade-cluster-target.yaml"
+import NodeSelector from "!!raw-loader!./examples/upgrade/upgrade-node-selector.yaml"
+import UpgradeForce from "!!raw-loader!./examples/upgrade/upgrade-force.yaml"
+import UpgradeRecovery from "!!raw-loader!./examples/upgrade/upgrade-recovery.yaml"
+import ManagedOSVersion from "!!raw-loader!./examples/upgrade/upgrade-managedos-version.yaml"
 
 # Upgrade
 


### PR DESCRIPTION
We never versioned the yaml examples directory, we always shared the yaml examples among all the versions.
The current "Next" version of Elemental (1.7.x) reworks the "Label Templates" changing the syntax. The examples have been updated accordingly, but this changed the examples also for the previous versions.

This was the root issue causing #416 .
#455 fixed the hostname syntax for 1.6.x and previous versions but also changed the preferred syntax in the "Next"  version.
Still the label template values for capturing the BIOS versions in the examples for versioned docs < 1.7.x is wrong.

This PR reverts #455 and versions the "examples" directory as we did for the "partials" and "images" and adopts yaml files before the Label Templates rework.