### PR TITLE
Declarative Networking: warn it's experimental

### DIFF
--- a/docs/networking-static.md
+++ b/docs/networking-static.md
@@ -9,6 +9,11 @@ title: ''
 
 import YipNmcStaticConfig from "!!raw-loader!@site/examples/network/yip-nmc-static-config.yaml"
 
+:::warning warning
+Declarative Networking is in **technology preview** state with limited support.  
+As such it is not recommended for production environments.
+:::
+
 ## Static Network with nm-configurator
 
 The `nm-configurator` [per node configuration](https://github.com/suse-edge/nm-configurator?tab=readme-ov-file#per-node-configurations) can be used to statically assign IP addresses to individual machines, based on the NIC's MAC addresses.  

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -13,6 +13,11 @@ import RegistrationWithNetworkNmstate from "!!raw-loader!@site/examples/network/
 import RegistrationWithNetworkNmconnections from "!!raw-loader!@site/examples/network/machineregistration-nmconnections.yaml"
 import YipNmcStaticConfig from "!!raw-loader!@site/examples/network/yip-nmc-static-config.yaml"
 
+:::warning warning
+Declarative Networking is in **technology preview** state with limited support.  
+As such it is not recommended for production environments.
+:::
+
 ## Network configuration with Elemental
 
 The [MachineRegistration](machineregistration-reference) supports Declarative Networking and integration with [CAPI IPAM Providers](https://github.com/kubernetes-sigs/cluster-api/blob/main/docs/proposals/20220125-ipam-integration.md#ipam-provider).  


### PR DESCRIPTION
IPAM installation and/or nmc installation cannot be really supported at present as they require manual installation of components out of Elemental lifecycle.
While they are well documented we should also be clear there will be a limited support on these kind of scenarios.