### PR TITLE
Fix typo for hostname in cloud-config example

### DIFF
--- a/docs/cloud-config-reference.md
+++ b/docs/cloud-config-reference.md
@@ -224,7 +224,7 @@ runcmd:
 - echo hello world
 
 # Hostname
-hostame: myserver
+hostname: myserver
 
 # Write arbitrary files
 write_files:


### PR DESCRIPTION
Current docs have:

```
hostame: myserver
```

where it should be "hostname:"

Ref: https://elemental.docs.rancher.com/cloud-config-reference#compatibility-with-cloud-init-format