### PR TITLE
Add OneTrust to ensure compliance

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -203,6 +203,21 @@ const config = {
         additionalLanguages: ['docker'],
       },
     }),
+
+  scripts: [
+    {
+      src: 'https://cdn.cookielaw.org/scripttemplates/otSDKStub.js',
+      type:'text/javascript',
+      charset: 'UTF-8',
+      'data-domain-script': '0f98beb0-fc4c-417d-a42e-564e2cae42d2',
+      async: true
+    },
+    {
+      src: '/scripts/optanonwrapper.js',
+      type:'text/javascript',
+      async: true
+    },
+  ],
 };
 
 module.exports = config;

--- a/static/scripts/optanonwrapper.js
+++ b/static/scripts/optanonwrapper.js
@@ -1,0 +1,1 @@
+function OptanonWrapper() { }


### PR DESCRIPTION
Requested by SD-192521. 

> Since we have Google Analytics on the domain, it is necessary to implement OneTrust to ensure compliance.

<img width="1514" height="147" alt="onetrust-1" src="https://github.com/user-attachments/assets/41a6ec35-2989-4f96-b310-5299657f3e10" />

<img width="475" height="888" alt="onetrust-2" src="https://github.com/user-attachments/assets/2ba6ee4f-bda9-41cb-8458-5c3e27a3c468" />
