### PR TITLE
Hostname reference was updated in example code block but not paragraph

### DIFF
--- a/docs/hostname.md
+++ b/docs/hostname.md
@@ -57,7 +57,7 @@ import Registration from "!!raw-loader!@site/examples/quickstart/registration-ha
 ### Keep the hostname assigned from DHCP
 In order to keep the hostname assigned from the DHCP server before the host registers to the operator,
 the `MachineRegistration` [`machineName field`](machineregistration-reference.md#machinename) should be set
-to the `${System Data/Runtime/Hostname}` [Hardware Label](hardwarelabels.md).
+to the `${Runtime/Hostname}` [Hardware Label](hardwarelabels.md).
 
 This way Elemental will use the current hostname as the `MachineInventory` name during
 the registration phase, which will be later set as the static hostname of the host during the


### PR DESCRIPTION
The leading paragraph contains a now-stale reference for using DHCP hostname for machine name:

<img width="989" height="787" alt="image" src="https://github.com/user-attachments/assets/ad2ea017-5529-45ea-8258-b2a2890c387d" />

The code block is the correct one at least as of Elemental 1.9, ref. https://github.com/rancher/elemental-docs/blob/7480d9458d06ba310c7625247170f9849693fe5e/examples/quickstart/registration-hardware-dhcphostname.yaml#L7 and https://github.com/rancher/elemental-docs/commit/1b59a53e538ab851c51024589c37795daa8924cf .